### PR TITLE
Added assetPath logic for 'root' site scenarios

### DIFF
--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -451,12 +451,12 @@ function getIndices(ref, data) {
 function getStyles(name, slug) {
   const site = siteService.sites()[slug],
     assetDir = site && site.assetDir || mediaDir,
-    assetDirLen = assetDir.length,
-    assetPath = site && site.assetPath || '';
+    assetDirLen = assetDir.length;
+  let assetPath = site && site.assetPath || '';
 
-   if (site.assetPath != site.path) {
-      assetPath = site && site.path || '';
-    }
+  if (site && site.path && site.assetPath !== site.path) {
+    assetPath = site.path;
+  }
 
   return _.map(_.filter([
     path.join(assetDir, 'css', name + '.css'),
@@ -473,12 +473,12 @@ function getStyles(name, slug) {
 function getScripts(name, slug) {
   const site = siteService.sites()[slug],
     assetDir = site && site.assetDir || mediaDir,
-    assetDirLen = assetDir.length,
-    assetPath = site && site.assetPath || '';
+    assetDirLen = assetDir.length;
+  let assetPath = site && site.assetPath || '';
 
-   if (site.assetPath != site.path) {
-      assetPath = site && site.path || '';
-    }
+  if (site && site.path && site.assetPath !== site.path) {
+    assetPath = site.path;
+  }
 
   return _.map(_.filter([
     path.join(assetDir, 'js', name + '.js'),

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -454,6 +454,10 @@ function getStyles(name, slug) {
     assetDirLen = assetDir.length,
     assetPath = site && site.assetPath || '';
 
+   if (site.assetPath != site.path) {
+      assetPath = site && site.path || '';
+    }
+
   return _.map(_.filter([
     path.join(assetDir, 'css', name + '.css'),
     path.join(assetDir, 'css', name + '.' + slug + '.css')
@@ -471,6 +475,10 @@ function getScripts(name, slug) {
     assetDir = site && site.assetDir || mediaDir,
     assetDirLen = assetDir.length,
     assetPath = site && site.assetPath || '';
+
+   if (site.assetPath != site.path) {
+      assetPath = site && site.path || '';
+    }
 
   return _.map(_.filter([
     path.join(assetDir, 'js', name + '.js'),

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -624,6 +624,22 @@ describe(_.startCase(filename), function () {
 
       expect(fn('name', 'slug')).to.deep.equal(['/someAssetPath/js/name.js', '/someAssetPath/js/name.slug.js']);
     });
+    
+    it('accepts good component with slug (with slug file) with assetDir and assetPath and path', function () {
+      siteService.sites.returns({slug: {assetDir: 'someAssetDir', path: '/scienceofus', assetPath: '/scienceofus'}});
+      files.fileExists.withArgs('someAssetDir/js/name.js').returns(true);
+      files.fileExists.withArgs('someAssetDir/js/name.slug.js').returns(true);
+
+      expect(fn('name', 'slug')).to.deep.equal(['/scienceofus/js/name.js', '/scienceofus/js/name.slug.js']);
+    });  
+
+    it('accepts good component with slug (with slug file) with assetDir and assetPath and path', function () {
+      siteService.sites.returns({slug: {assetDir: 'someAssetDir', path: '/', assetPath: '/vulture'}});
+      files.fileExists.withArgs('someAssetDir/js/name.js').returns(true);
+      files.fileExists.withArgs('someAssetDir/js/name.slug.js').returns(true);
+
+      expect(fn('name', 'slug')).to.deep.equal(['/js/name.js', '/js/name.slug.js']);
+    });     
   });
 
   describe('getStyles', function () {
@@ -666,12 +682,28 @@ describe(_.startCase(filename), function () {
       expect(fn('name', 'slug')).to.deep.equal(['/css/name.css', '/css/name.slug.css']);
     });
 
-    it('accepts good component with slug (with slug file) with assetDir and assetPath', function () {
+    it('sometimes accepts good component with slug (with slug file) with assetDir and assetPath', function () {
       siteService.sites.returns({slug: {assetDir: 'someAssetDir', assetPath: '/someAssetPath'}});
       files.fileExists.withArgs('someAssetDir/css/name.css').returns(true);
       files.fileExists.withArgs('someAssetDir/css/name.slug.css').returns(true);
 
       expect(fn('name', 'slug')).to.deep.equal(['/someAssetPath/css/name.css', '/someAssetPath/css/name.slug.css']);
     });
+
+    it('accepts good component with slug (with slug file) with assetDir and assetPath and path', function () {
+      siteService.sites.returns({slug: {assetDir: 'someAssetDir', path: '/scienceofus', assetPath: '/scienceofus'}});
+      files.fileExists.withArgs('someAssetDir/css/name.css').returns(true);
+      files.fileExists.withArgs('someAssetDir/css/name.slug.css').returns(true);
+
+      expect(fn('name', 'slug')).to.deep.equal(['/scienceofus/css/name.css', '/scienceofus/css/name.slug.css']);
+    });  
+
+    it('accepts good component with slug (with slug file) with assetDir and assetPath and path', function () {
+      siteService.sites.returns({slug: {assetDir: 'someAssetDir', path: '/', assetPath: '/vulture'}});
+      files.fileExists.withArgs('someAssetDir/css/name.css').returns(true);
+      files.fileExists.withArgs('someAssetDir/css/name.slug.css').returns(true);
+
+      expect(fn('name', 'slug')).to.deep.equal(['/css/name.css', '/css/name.slug.css']);
+    });   
   });
 });


### PR DESCRIPTION
This fixes style and js references for sites like "vulture" and "grubstreet" where site path is "/" and assetPath setting is "/vulture"
