### PR TITLE
update memory leak limit to appropriate level

### DIFF
--- a/lib/control.js
+++ b/lib/control.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let memoryLeakThreshold = 1000;
+let memoryLeakThreshold = 32768;
 const _ = require('lodash'),
   log = require('./services/log').withStandardPrefix(__filename),
   minute = 60000;


### PR DESCRIPTION
Helps make the logs more readable. Stops reporting false memory leak conditions.