### PR TITLE
Environment Variables

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uriRoutes, renderers, envVars;
+var uriRoutes, renderers;
 const _ = require('lodash'),
   media = require('./media'),
   schema = require('./schema'),
@@ -44,7 +44,6 @@ function registerRenderers(renderObj) {
  * @param  {Array} envArray
  */
 function registerEnv(envArray) {
-  envVars = envArray;
   // Export the renderers object
   module.exports.envVars = envArray;
 }
@@ -101,7 +100,7 @@ function resolveEnvVars() {
  */
 function applyOptions(options, locals) {
   return function (result) {
-    let state, { site } = locals, componentList, envVars;
+    let state, { site } = locals, componentList;
 
     // Initial state object which is the response payload
     state = {

--- a/lib/render.js
+++ b/lib/render.js
@@ -13,7 +13,8 @@ const _ = require('lodash'),
   db = require('./services/db'),
   log = require('./services/log').withStandardPrefix(__filename),
   composer = require('./services/composer'),
-  mapLayoutToPageData = require('./utils/layout-to-page-data');
+  mapLayoutToPageData = require('./utils/layout-to-page-data'),
+  control = require('./control');
 
 /**
  * Check the renderers for the request extension. If the
@@ -46,7 +47,6 @@ function registerEnv(envArray) {
   envVars = envArray;
   // Export the renderers object
   module.exports.envVars = envArray;
-  console.log('!!!!!!', module.exports.envVars);
 }
 
 /**
@@ -78,8 +78,10 @@ function transfer(from, to, fromProp, toProp) {
 }
 
 /**
- * [resolveEnvVars description]
- * @return {[type]} [description]
+ * Look through env variables array and return
+ * the variables from the `process.env` bject
+ *
+ * @return {Object}
  */
 function resolveEnvVars() {
   var obj = {};
@@ -110,7 +112,7 @@ function applyOptions(options, locals) {
     // If we're in edit mode then we want to send across the
     // environment variables that model.js files might need.
     if (locals.edit) {
-      state._envVars = resolveEnvVars();
+      state._envVars = module.exports.resolveEnvVars();
     }
 
     // Get an array of components that are included in the request. This
@@ -421,6 +423,7 @@ module.exports.renderPage = renderPage;
 module.exports.renderUri = renderUri;
 module.exports.formDataForRenderer = formDataForRenderer;
 module.exports.applyOptions = applyOptions;
+module.exports.resolveEnvVars = control.memoize(resolveEnvVars);
 
 // Render Utils
 module.exports.rendererExists = rendererExists;
@@ -435,7 +438,6 @@ module.exports.registerRenderers = registerRenderers;
 module.exports.registerEnv = registerEnv;
 
 // For Testing
-module.exports.resolveEnvVars = resolveEnvVars;
 module.exports.resetUriRouteHandlers = resetUriRouteHandlers;
 module.exports.setUriRouteHandlers = setUriRouteHandlers;
 module.exports.assumePublishedUnlessEditing = assumePublishedUnlessEditing;

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uriRoutes, renderers;
+var uriRoutes, renderers, envVars;
 const _ = require('lodash'),
   media = require('./media'),
   schema = require('./schema'),
@@ -38,6 +38,18 @@ function registerRenderers(renderObj) {
 }
 
 /**
+ * Register env variables to be referenced
+ *
+ * @param  {Array} envArray
+ */
+function registerEnv(envArray) {
+  envVars = envArray;
+  // Export the renderers object
+  module.exports.envVars = envArray;
+  console.log('!!!!!!', module.exports.envVars);
+}
+
+/**
  *
  * @param {string} ref
  * @param {object} data
@@ -66,6 +78,20 @@ function transfer(from, to, fromProp, toProp) {
 }
 
 /**
+ * [resolveEnvVars description]
+ * @return {[type]} [description]
+ */
+function resolveEnvVars() {
+  var obj = {};
+
+  _.map(module.exports.envVars, function (val) {
+    obj[val] = process.env[val];
+  });
+
+  return obj;
+}
+
+/**
  * Add state to result, which adds functionality and information about this request to the templates.
  * @param {object} options
  * @param {object} locals
@@ -73,13 +99,19 @@ function transfer(from, to, fromProp, toProp) {
  */
 function applyOptions(options, locals) {
   return function (result) {
-    let state, { site } = locals, componentList;
+    let state, { site } = locals, componentList, envVars;
 
     // Initial state object which is the response payload
     state = {
       site,
       locals
     };
+
+    // If we're in edit mode then we want to send across the
+    // environment variables that model.js files might need.
+    if (locals.edit) {
+      state._envVars = resolveEnvVars();
+    }
 
     // Get an array of components that are included in the request. This
     // includes the root component (layout or other) that is at the base
@@ -92,7 +124,8 @@ function applyOptions(options, locals) {
     transfer(options, state, 'pageRef', '_self');
     transfer(options, state, 'pageData', '_pageData');
     transfer(options, state, 'version', '_version');
-    transfer(options, state, 'layoutRef', '_layoutRef'); // TODO: collapse layoutRef and pageRef into the same prop name?
+    transfer(options, state, 'layoutRef', '_layoutRef');
+
 
     // Add the list of components to the payload
     _.set(state, '_components', componentList);
@@ -397,9 +430,12 @@ module.exports.transfer = transfer;
 
 // Setup
 module.exports.renderers = {}; // Overriden when a user registers a render object
+module.exports.envVars = [];
 module.exports.registerRenderers = registerRenderers;
+module.exports.registerEnv = registerEnv;
 
 // For Testing
+module.exports.resolveEnvVars = resolveEnvVars;
 module.exports.resetUriRouteHandlers = resetUriRouteHandlers;
 module.exports.setUriRouteHandlers = setUriRouteHandlers;
 module.exports.assumePublishedUnlessEditing = assumePublishedUnlessEditing;

--- a/lib/render.test.js
+++ b/lib/render.test.js
@@ -384,8 +384,8 @@ describe(_.startCase(filename), function () {
         callback = fn({}, locals),
         returnVal = callback({});
 
-        sandbox.stub(lib, 'resolveEnvVars');
-        expect(returnVal._envVars).to.eql({ foo: undefined, bar: undefined })
+      sandbox.stub(lib, 'resolveEnvVars');
+      expect(returnVal._envVars).to.eql({ foo: undefined, bar: undefined });
     });
   });
 

--- a/lib/render.test.js
+++ b/lib/render.test.js
@@ -355,6 +355,8 @@ describe(_.startCase(filename), function () {
   describe('applyOptions', function () {
     const fn = lib[this.title];
 
+    lib.registerEnv(['foo', 'bar']);
+
     it('consolidates all request information to be sent to the rendererer', function () {
       const locals = {
           site: {
@@ -371,7 +373,23 @@ describe(_.startCase(filename), function () {
       expect(returnVal._media).to.have.property('styles');
       expect(returnVal._media).to.have.property('styles');
     });
+
+    it('calls `resolveEnvVars` if the request is for edit mode', function () {
+      const locals = {
+          site: {
+            slug: 'site'
+          },
+          edit: 'true'
+        },
+        callback = fn({}, locals),
+        returnVal = callback({});
+
+        sandbox.stub(lib, 'resolveEnvVars');
+        expect(returnVal._envVars).to.eql({ foo: undefined, bar: undefined })
+    });
   });
+
+
 
   describe('transfer', function () {
     const fn = lib[this.title];

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -22,7 +22,7 @@ bluebird.config({
  * @returns {Promise}
  */
 module.exports = function (options) {
-  let app, providers, router, sessionStore, renderers, appPlugins;
+  let app, providers, router, sessionStore, renderers, appPlugins, env;
 
   options = options || {};
   app = options.app || express(); // use new express app if not passed in
@@ -30,6 +30,7 @@ module.exports = function (options) {
   sessionStore = options.sessionStore;
   renderers = options.renderers; // TODO: DOCUMENT THIS
   appPlugins = options.plugins; // TODO: DOCUMENT THIS
+  env = options.env || [];      // TODO: DOCUMENT THIS
 
   // Init plugins
   if (appPlugins) {
@@ -42,6 +43,7 @@ module.exports = function (options) {
   // if engines were passed in, send them to the renderer
   if (renderers) {
     render.registerRenderers(renderers);
+    render.registerEnv(env);
   }
 
   // look for bootstraps in components

--- a/lib/setup.test.js
+++ b/lib/setup.test.js
@@ -14,6 +14,7 @@ describe(_.startCase(filename), function () {
     sandbox = sinon.sandbox.create();
     sandbox.stub(plugins, 'registerPlugins');
     sandbox.stub(render, 'registerRenderers');
+    sandbox.stub(render, 'registerEnv');
   });
 
   afterEach(function () {
@@ -47,6 +48,12 @@ describe(_.startCase(filename), function () {
   it('registers renderers', function () {
     return lib({ renderers: { default: 'html', html: _.noop } }).then(function () {
       sinon.assert.calledOnce(render.registerRenderers);
+    });
+  });
+
+  it('registers env vars', function () {
+    return lib({ renderers: { default: 'html', html: _.noop } }).then(function () {
+      sinon.assert.calledOnce(render.registerEnv);
     });
   });
 });


### PR DESCRIPTION
Per [ticket](https://trello.com/c/amgms8v6/19-exposing-env-variables-to-client).

Register the needed environment variables with Amphora at instantiation time:
```javascript
   amphora({
      app: app,
      renderers: {
        html: amphoraHtml,
        default: 'html'
      },
      env: ['FOO', 'BAR']
    }).then(....)
```

These will then be resolved into an object when a page is requested for render _only in edit mode_. They will be sent in the `_envVars` property on the `state` object. 


