### PR TITLE
Permissions

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -11,7 +11,12 @@ const _ = require('lodash'),
   basicAuth = require('basic-auth'),
   fs = require('fs'),
   path = require('path'),
-  USER_LEVELS = {
+  AUTH_LEVELS_MAP = {
+    ADMIN: 'admin',
+    WRITE: 'write',
+    READ: 'read'
+  },
+  AUTH_LEVEL_VALUES = {
     admin: 0,
     write: 1,
     read: 2
@@ -26,13 +31,13 @@ const _ = require('lodash'),
  * @return {Boolean}
  */
 function checkAuthLevel(userLevel, requiredLevel) {
-  console.log(userLevel);
   // User has to have an auth level set
   if (!userLevel) {
     throw new Error('User does not have an authentication level set');
   }
+
   // Compare levels, the lover you go the more permissions you have
-  return USER_LEVELS[userLevel] <= USER_LEVELS[requiredLevel];
+  return AUTH_LEVEL_VALUES[userLevel] <= AUTH_LEVEL_VALUES[requiredLevel];
 }
 
 /**
@@ -45,11 +50,8 @@ function checkAuthLevel(userLevel, requiredLevel) {
  */
 function withAuthLevel(requiredLevel) {
   return function (req, res, next) {
-    if (!req.user) {
-      // TODO: dssdsdfdsf
-      // If no user is set, we might be dealing with an API key, let the request proceed
-      next();
-    } else if (checkAuthLevel(_.get(req, 'user.auth', ''), requiredLevel)) {
+    console.log(req.user);
+    if (checkAuthLevel(_.get(req, 'user.auth', ''), requiredLevel)) {
       // If the user exists and meets the level requirement, let the request proceed
       next();
     } else {
@@ -293,6 +295,8 @@ function createLDAPStrategy(site) {
  */
 function apiCallback(apikey, done) {
   if (apikey === process.env.CLAY_ACCESS_KEY) {
+    // If we're using an API Key then we're assuming the user is
+    // has admin privileges by defining the auth level in the next line
     done(null, { provider: 'apikey', auth: 'admin' });
   } else {
     done(null, false, { message: 'Unknown apikey: ' + apikey });
@@ -539,6 +543,7 @@ function init(router, providers, site, sessionStore) {
 
 module.exports.init = init;
 module.exports.withAuthLevel = withAuthLevel;
+module.exports.authLevels = AUTH_LEVELS_MAP;
 
 // for testing
 module.exports.isProtectedRoute = isProtectedRoute;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -13,13 +13,7 @@ const _ = require('lodash'),
   path = require('path'),
   AUTH_LEVELS_MAP = {
     ADMIN: 'admin',
-    WRITE: 'write',
-    READ: 'read'
-  },
-  AUTH_LEVEL_VALUES = {
-    admin: 0,
-    write: 1,
-    read: 2
+    WRITE: 'write'
   };
 
 /**
@@ -36,8 +30,13 @@ function checkAuthLevel(userLevel, requiredLevel) {
     throw new Error('User does not have an authentication level set');
   }
 
-  // Compare levels, the lover you go the more permissions you have
-  return AUTH_LEVEL_VALUES[userLevel] <= AUTH_LEVEL_VALUES[requiredLevel];
+  if (userLevel === AUTH_LEVELS_MAP.ADMIN) {
+    return true;
+  } else if (userLevel !== requiredLevel) {
+    return false;
+  } else {
+    return true;
+  }
 }
 
 /**

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -50,7 +50,6 @@ function checkAuthLevel(userLevel, requiredLevel) {
  */
 function withAuthLevel(requiredLevel) {
   return function (req, res, next) {
-    console.log(req.user);
     if (checkAuthLevel(_.get(req, 'user.auth', ''), requiredLevel)) {
       // If the user exists and meets the level requirement, let the request proceed
       next();
@@ -201,7 +200,8 @@ function createTwitterStrategy(site) {
     username: 'username',
     imageUrl: 'photos[0].value',
     name: 'displayName',
-    provider: 'twitter'
+    provider: 'twitter',
+    auth: 'auth'
   }, site)));
 }
 
@@ -245,7 +245,8 @@ function createSlackStrategy(site) {
     username: '_json.user',
     imageUrl: '_json.info.user.profile.image_1024',
     name: '_json.info.user.real_name',
-    provider: 'slack'
+    provider: 'slack',
+    auth: 'auth'
   }, site)));
 }
 
@@ -263,7 +264,8 @@ function verifyLdap(site) {
       username: 'sAMAccountName',
       imageUrl: '', // ldap generally has no images
       name: 'displayName',
-      provider: 'ldap'
+      provider: 'ldap',
+      auth: 'auth'
     }, site)(req, null, null, user, done); // eslint-disable-line
   };
 }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -55,9 +55,9 @@ function withAuthLevel(requiredLevel) {
       next();
     } else {
       // None of the above, we need to error
-      responses.unauthorized(req, res, next)
+      responses.unauthorized(req, res, next);
     }
-  }
+  };
 }
 
 /**
@@ -146,7 +146,6 @@ function verify(properties, site) {
       imageUrl = _.get(profile, properties.imageUrl),
       name = _.get(profile, properties.name),
       provider = properties.provider,
-      auth = properties.auth,
       uid;
 
     if (!username) {
@@ -200,8 +199,7 @@ function createTwitterStrategy(site) {
     username: 'username',
     imageUrl: 'photos[0].value',
     name: 'displayName',
-    provider: 'twitter',
-    auth: 'auth'
+    provider: 'twitter'
   }, site)));
 }
 
@@ -222,8 +220,7 @@ function createGoogleStrategy(site) {
     username: 'emails[0].value',
     imageUrl: 'photos[0].value',
     name: 'displayName',
-    provider: 'google',
-    auth: 'auth'
+    provider: 'google'
   }, site)));
 }
 
@@ -245,8 +242,7 @@ function createSlackStrategy(site) {
     username: '_json.user',
     imageUrl: '_json.info.user.profile.image_1024',
     name: '_json.info.user.real_name',
-    provider: 'slack',
-    auth: 'auth'
+    provider: 'slack'
   }, site)));
 }
 
@@ -264,8 +260,7 @@ function verifyLdap(site) {
       username: 'sAMAccountName',
       imageUrl: '', // ldap generally has no images
       name: 'displayName',
-      provider: 'ldap',
-      auth: 'auth'
+      provider: 'ldap'
     }, site)(req, null, null, user, done); // eslint-disable-line
   };
 }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -6,10 +6,58 @@ const _ = require('lodash'),
   references = require('./services/references'),
   session = require('express-session'),
   flash = require('express-flash'),
+  responses = require('./responses'),
   handlebars = require('handlebars'),
   basicAuth = require('basic-auth'),
   fs = require('fs'),
-  path = require('path');
+  path = require('path'),
+  USER_LEVELS = {
+    admin: 0,
+    write: 1,
+    read: 2
+  };
+
+/**
+ * Check the auth level to see if a user
+ * has sufficient permissions
+ *
+ * @param  {String} userLevel
+ * @param  {String} requiredLevel
+ * @return {Boolean}
+ */
+function checkAuthLevel(userLevel, requiredLevel) {
+  console.log(userLevel);
+  // User has to have an auth level set
+  if (!userLevel) {
+    throw new Error('User does not have an authentication level set');
+  }
+  // Compare levels, the lover you go the more permissions you have
+  return USER_LEVELS[userLevel] <= USER_LEVELS[requiredLevel];
+}
+
+/**
+ * Get the user auth level and check it against the
+ * required auth level for a route. Send an error
+ * if the user doesn't have permissions
+ *
+ * @param  {String} requiredLevel
+ * @return {Function}
+ */
+function withAuthLevel(requiredLevel) {
+  return function (req, res, next) {
+    if (!req.user) {
+      // TODO: dssdsdfdsf
+      // If no user is set, we might be dealing with an API key, let the request proceed
+      next();
+    } else if (checkAuthLevel(_.get(req, 'user.auth', ''), requiredLevel)) {
+      // If the user exists and meets the level requirement, let the request proceed
+      next();
+    } else {
+      // None of the above, we need to error
+      responses.unauthorized(req, res, next)
+    }
+  }
+}
 
 /**
  * determine if a route is protected
@@ -97,6 +145,7 @@ function verify(properties, site) {
       imageUrl = _.get(profile, properties.imageUrl),
       name = _.get(profile, properties.name),
       provider = properties.provider,
+      auth = properties.auth,
       uid;
 
     if (!username) {
@@ -171,7 +220,8 @@ function createGoogleStrategy(site) {
     username: 'emails[0].value',
     imageUrl: 'photos[0].value',
     name: 'displayName',
-    provider: 'google'
+    provider: 'google',
+    auth: 'auth'
   }, site)));
 }
 
@@ -243,7 +293,7 @@ function createLDAPStrategy(site) {
  */
 function apiCallback(apikey, done) {
   if (apikey === process.env.CLAY_ACCESS_KEY) {
-    done(null, { provider: 'apikey' });
+    done(null, { provider: 'apikey', auth: 'admin' });
   } else {
     done(null, false, { message: 'Unknown apikey: ' + apikey });
   }
@@ -488,6 +538,7 @@ function init(router, providers, site, sessionStore) {
 }
 
 module.exports.init = init;
+module.exports.withAuthLevel = withAuthLevel;
 
 // for testing
 module.exports.isProtectedRoute = isProtectedRoute;

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -199,7 +199,7 @@ function notAcceptable(options) {
   };
 }
 
-function unauthorized(req, res, next) {
+function unauthorized(req, res) {
   let code = 401,
     message = 'Insufficient permissions to perform action';
 

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -199,6 +199,13 @@ function notAcceptable(options) {
   };
 }
 
+function unauthorized(req, res, next) {
+  let code = 401,
+    message = 'Insufficient permissions to perform action';
+
+  sendDefaultResponseForCode(code, message, res);
+}
+
 /**
  * @param {object} req
  * @param {object} res
@@ -544,7 +551,7 @@ module.exports.getUri = getUri;
 // error responses
 module.exports.clientError = clientError; // 400 client error
 module.exports.notFound = notFound; // 404 not found
-
+module.exports.unauthorized = unauthorized;
 module.exports.methodNotAllowed = methodNotAllowed; // nice 405
 module.exports.notAcceptable = notAcceptable; // nice 406
 module.exports.notImplemented = notImplemented; // nice 500

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -12,10 +12,13 @@ const _ = require('lodash'),
   files = require('../files'),
   queryStringOptions = ['ignore-data'],
   controller = require('../services/components'),
+  withAuthLevel = require('../auth').withAuthLevel,
   acceptedExtensions = {
     html: 'text/html',
     json: 'application/json'
-  };
+  },
+  WRITE = 'write',
+  ADMIN = 'admin';
 
 let validation, route;
 
@@ -233,6 +236,7 @@ function routes(router) {
   router.all('/:name@:version', responses.denyTrailingSlashOnId);
   router.get('/:name@:version', route.get);
   router.put('/:name@:version', responses.denyReferenceAtRoot);
+  router.put('/:name@:version', withAuthLevel(WRITE));
   router.put('/:name@:version', route.put);
 
   router.all('/:name', responses.acceptJSONOnly);
@@ -242,7 +246,9 @@ function routes(router) {
   router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', route.get);
   router.put('/:name', responses.denyReferenceAtRoot);
+  router.put('/:name', withAuthLevel(WRITE));
   router.put('/:name', route.put);
+  router.delete('/:name', withAuthLevel(ADMIN));
   router.delete('/:name', route.del);
 
   router.all('/:name/instances', responses.acceptJSONOnly);
@@ -251,6 +257,7 @@ function routes(router) {
   }));
   router.get('/:name/instances', responses.listWithoutVersions());
   router.post('/:name/instances', responses.denyReferenceAtRoot);
+  router.post('/:name/instances', withAuthLevel(WRITE));
   router.post('/:name/instances', route.post);
 
   router.all('/:name/instances/:id.:ext', responses.methodNotAllowed({
@@ -264,27 +271,36 @@ function routes(router) {
   router.put('/:name/instances/:id.:ext', responses.onlyAcceptExtensions({
     extensions: acceptedExtensions
   }));
+  router.put('/:name/instances/:id.:ext', withAuthLevel(WRITE));
   router.put('/:name/instances/:id.:ext', route.putExtension);
 
   router.all('/:name/instances/:id@:version', responses.acceptJSONOnly);
   router.all('/:name/instances/:id@:version', responses.methodNotAllowed({
     allow: ['get', 'put', 'delete']
   }));
+
+
   router.all('/:name/instances/:id@:version', responses.denyTrailingSlashOnId);
   router.get('/:name/instances/:id@:version', route.get);
+  router.put('/:name/instances/:id@:version', withAuthLevel(WRITE));
   router.put('/:name/instances/:id@:version', responses.denyReferenceAtRoot);
+  router.put('/:name/instances/:id@published', withAuthLevel(ADMIN));
   router.put('/:name/instances/:id@published', route.published);
   router.put('/:name/instances/:id@:version', route.put);
+  router.delete('/:name/instances/:id@:version', withAuthLevel(ADMIN));
   router.delete('/:name/instances/:id@:version', route.del);
 
+  // router.use('/:name/instances/:id', );
   router.all('/:name/instances/:id', responses.acceptJSONOnly);
   router.all('/:name/instances/:id', responses.methodNotAllowed({
     allow: ['get', 'put', 'delete']
   }));
   router.all('/:name/instances/:id', responses.denyTrailingSlashOnId);
   router.get('/:name/instances/:id', route.get);
+  router.put('/:name/instances/:id', withAuthLevel(WRITE));
   router.put('/:name/instances/:id', responses.denyReferenceAtRoot);
   router.put('/:name/instances/:id', route.put);
+  router.delete('/:name/instances/:id', withAuthLevel(ADMIN));
   router.delete('/:name/instances/:id', route.del);
 
   router.all('/:name/schema', responses.methodNotAllowed({

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -12,13 +12,12 @@ const _ = require('lodash'),
   files = require('../files'),
   queryStringOptions = ['ignore-data'],
   controller = require('../services/components'),
-  withAuthLevel = require('../auth').withAuthLevel,
+  { withAuthLevel, authLevels } = require('../auth'),
   acceptedExtensions = {
     html: 'text/html',
     json: 'application/json'
-  },
-  WRITE = 'write',
-  ADMIN = 'admin';
+  };
+
 
 let validation, route;
 
@@ -236,7 +235,7 @@ function routes(router) {
   router.all('/:name@:version', responses.denyTrailingSlashOnId);
   router.get('/:name@:version', route.get);
   router.put('/:name@:version', responses.denyReferenceAtRoot);
-  router.put('/:name@:version', withAuthLevel(WRITE));
+  router.put('/:name@:version', withAuthLevel(authLevels.WRITE));
   router.put('/:name@:version', route.put);
 
   router.all('/:name', responses.acceptJSONOnly);
@@ -246,9 +245,9 @@ function routes(router) {
   router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', route.get);
   router.put('/:name', responses.denyReferenceAtRoot);
-  router.put('/:name', withAuthLevel(WRITE));
+  router.put('/:name', withAuthLevel(authLevels.WRITE));
   router.put('/:name', route.put);
-  router.delete('/:name', withAuthLevel(ADMIN));
+  router.delete('/:name', withAuthLevel(authLevels.ADMIN));
   router.delete('/:name', route.del);
 
   router.all('/:name/instances', responses.acceptJSONOnly);
@@ -257,7 +256,7 @@ function routes(router) {
   }));
   router.get('/:name/instances', responses.listWithoutVersions());
   router.post('/:name/instances', responses.denyReferenceAtRoot);
-  router.post('/:name/instances', withAuthLevel(WRITE));
+  router.post('/:name/instances', withAuthLevel(authLevels.WRITE));
   router.post('/:name/instances', route.post);
 
   router.all('/:name/instances/:id.:ext', responses.methodNotAllowed({
@@ -271,7 +270,7 @@ function routes(router) {
   router.put('/:name/instances/:id.:ext', responses.onlyAcceptExtensions({
     extensions: acceptedExtensions
   }));
-  router.put('/:name/instances/:id.:ext', withAuthLevel(WRITE));
+  router.put('/:name/instances/:id.:ext', withAuthLevel(authLevels.WRITE));
   router.put('/:name/instances/:id.:ext', route.putExtension);
 
   router.all('/:name/instances/:id@:version', responses.acceptJSONOnly);
@@ -282,12 +281,12 @@ function routes(router) {
 
   router.all('/:name/instances/:id@:version', responses.denyTrailingSlashOnId);
   router.get('/:name/instances/:id@:version', route.get);
-  router.put('/:name/instances/:id@:version', withAuthLevel(WRITE));
+  router.put('/:name/instances/:id@:version', withAuthLevel(authLevels.WRITE));
   router.put('/:name/instances/:id@:version', responses.denyReferenceAtRoot);
-  router.put('/:name/instances/:id@published', withAuthLevel(WRITE));
+  router.put('/:name/instances/:id@published', withAuthLevel(authLevels.WRITE));
   router.put('/:name/instances/:id@published', route.published);
   router.put('/:name/instances/:id@:version', route.put);
-  router.delete('/:name/instances/:id@:version', withAuthLevel(ADMIN));
+  router.delete('/:name/instances/:id@:version', withAuthLevel(authLevels.ADMIN));
   router.delete('/:name/instances/:id@:version', route.del);
 
   // router.use('/:name/instances/:id', );
@@ -297,10 +296,10 @@ function routes(router) {
   }));
   router.all('/:name/instances/:id', responses.denyTrailingSlashOnId);
   router.get('/:name/instances/:id', route.get);
-  router.put('/:name/instances/:id', withAuthLevel(WRITE));
+  router.put('/:name/instances/:id', withAuthLevel(authLevels.WRITE));
   router.put('/:name/instances/:id', responses.denyReferenceAtRoot);
   router.put('/:name/instances/:id', route.put);
-  router.delete('/:name/instances/:id', withAuthLevel(ADMIN));
+  router.delete('/:name/instances/:id', withAuthLevel(authLevels.ADMIN));
   router.delete('/:name/instances/:id', route.del);
 
   router.all('/:name/schema', responses.methodNotAllowed({

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -284,7 +284,7 @@ function routes(router) {
   router.get('/:name/instances/:id@:version', route.get);
   router.put('/:name/instances/:id@:version', withAuthLevel(WRITE));
   router.put('/:name/instances/:id@:version', responses.denyReferenceAtRoot);
-  router.put('/:name/instances/:id@published', withAuthLevel(ADMIN));
+  router.put('/:name/instances/:id@published', withAuthLevel(WRITE));
   router.put('/:name/instances/:id@published', route.published);
   router.put('/:name/instances/:id@:version', route.put);
   router.delete('/:name/instances/:id@:version', withAuthLevel(ADMIN));

--- a/lib/routes/components.js
+++ b/lib/routes/components.js
@@ -18,7 +18,6 @@ const _ = require('lodash'),
     json: 'application/json'
   };
 
-
 let validation, route;
 
 /**

--- a/lib/routes/lists.js
+++ b/lib/routes/lists.js
@@ -8,9 +8,7 @@
 
 const _ = require('lodash'),
   responses = require('../responses'),
-  withAuthLevel = require('../auth').withAuthLevel,
-  WRITE = 'write',
-  ADMIN = 'admin';
+  { withAuthLevel, authLevels } = require('../auth');
 
 /**
  * @param {object} req
@@ -33,7 +31,7 @@ function routes(router) {
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put']}));
   router.get('/:name', responses.getRouteFromDB);
   router.use('/:name', onlyJSONLists);
-  router.put('/:name', withAuthLevel(WRITE));
+  router.put('/:name', withAuthLevel(authLevels.WRITE));
   router.put('/:name', responses.putRouteFromDB);
   router.post('/', responses.notImplemented);
 }

--- a/lib/routes/lists.js
+++ b/lib/routes/lists.js
@@ -7,7 +7,10 @@
 'use strict';
 
 const _ = require('lodash'),
-  responses = require('../responses');
+  responses = require('../responses'),
+  withAuthLevel = require('../auth').withAuthLevel,
+  WRITE = 'write',
+  ADMIN = 'admin';
 
 /**
  * @param {object} req
@@ -30,6 +33,7 @@ function routes(router) {
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put']}));
   router.get('/:name', responses.getRouteFromDB);
   router.use('/:name', onlyJSONLists);
+  router.put('/:name', withAuthLevel(WRITE));
   router.put('/:name', responses.putRouteFromDB);
   router.post('/', responses.notImplemented);
 }

--- a/lib/routes/pages.js
+++ b/lib/routes/pages.js
@@ -12,13 +12,11 @@ const _ = require('lodash'),
   controller = require('../services/pages'),
   composer = require('../services/composer'),
   db = require('../services/db'),
+  { withAuthLevel, authLevels } = require('../auth'),
   acceptedExtensions = {
     html: 'text/html',
     json: 'application/json'
-  },
-  withAuthLevel = require('../auth').withAuthLevel,
-  WRITE = 'write',
-  ADMIN = 'admin';
+  };
 
 // TODO: Remove `text/html` in 4.0
 
@@ -110,7 +108,7 @@ function routes(router) {
   router.all('/', responses.notAcceptable({accept: ['application/json']}));
   router.get('/', responses.listWithoutVersions());
   router.post('/', responses.denyReferenceAtRoot);
-  router.post('/', withAuthLevel(WRITE));
+  router.post('/', withAuthLevel(authLevels.WRITE));
   router.post('/', route.post);
 
   router.all('/:name.:ext', responses.methodNotAllowed({allow: ['get']}));
@@ -121,12 +119,12 @@ function routes(router) {
   router.all('/:name@:version', responses.acceptJSONOnly);
   router.all('/:name@:version', responses.denyTrailingSlashOnId);
   router.get('/:name@:version', responses.getRouteFromDB);
-  router.put('/:name@:version', withAuthLevel(WRITE));
+  router.put('/:name@:version', withAuthLevel(authLevels.WRITE));
   router.put('/:name@:version', responses.denyReferenceAtRoot);
   router.put('/:name@published', route.putPublish);
-  router.put('/:name@published', withAuthLevel(WRITE));
+  router.put('/:name@published', withAuthLevel(authLevels.WRITE));
   router.put('/:name@:version', responses.putRouteFromDB);
-  router.delete('/:name@:version', withAuthLevel(ADMIN));
+  router.delete('/:name@:version', withAuthLevel(authLevels.ADMIN));
   router.delete('/:name@:version', responses.deleteRouteFromDB);
 
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
@@ -134,9 +132,9 @@ function routes(router) {
   router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', responses.getRouteFromDB);
   router.put('/:name', responses.denyReferenceAtRoot);
-  router.put('/:name', withAuthLevel(WRITE));
+  router.put('/:name', withAuthLevel(authLevels.WRITE));
   router.put('/:name', responses.putRouteFromDB);
-  router.delete('/:name', withAuthLevel(ADMIN));
+  router.delete('/:name', withAuthLevel(authLevels.ADMIN));
   router.delete('/:name', responses.deleteRouteFromDB);
 }
 

--- a/lib/routes/pages.js
+++ b/lib/routes/pages.js
@@ -15,7 +15,10 @@ const _ = require('lodash'),
   acceptedExtensions = {
     html: 'text/html',
     json: 'application/json'
-  };
+  },
+  withAuthLevel = require('../auth').withAuthLevel,
+  WRITE = 'write',
+  ADMIN = 'admin';
 
 // TODO: Remove `text/html` in 4.0
 
@@ -107,6 +110,7 @@ function routes(router) {
   router.all('/', responses.notAcceptable({accept: ['application/json']}));
   router.get('/', responses.listWithoutVersions());
   router.post('/', responses.denyReferenceAtRoot);
+  router.post('/', withAuthLevel(WRITE));
   router.post('/', route.post);
 
   router.all('/:name.:ext', responses.methodNotAllowed({allow: ['get']}));
@@ -117,9 +121,12 @@ function routes(router) {
   router.all('/:name@:version', responses.acceptJSONOnly);
   router.all('/:name@:version', responses.denyTrailingSlashOnId);
   router.get('/:name@:version', responses.getRouteFromDB);
+  router.put('/:name@:version', withAuthLevel(WRITE));
   router.put('/:name@:version', responses.denyReferenceAtRoot);
   router.put('/:name@published', route.putPublish);
+  router.put('/:name@published', withAuthLevel(WRITE));
   router.put('/:name@:version', responses.putRouteFromDB);
+  router.delete('/:name@:version', withAuthLevel(ADMIN));
   router.delete('/:name@:version', responses.deleteRouteFromDB);
 
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
@@ -127,7 +134,9 @@ function routes(router) {
   router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', responses.getRouteFromDB);
   router.put('/:name', responses.denyReferenceAtRoot);
+  router.put('/:name', withAuthLevel(WRITE));
   router.put('/:name', responses.putRouteFromDB);
+  router.delete('/:name', withAuthLevel(ADMIN));
   router.delete('/:name', responses.deleteRouteFromDB);
 }
 

--- a/lib/routes/schedule.js
+++ b/lib/routes/schedule.js
@@ -8,7 +8,9 @@
 
 const _ = require('lodash'),
   responses = require('../responses'),
-  controller = require('../services/schedule');
+  controller = require('../services/schedule'),
+  withAuthLevel = require('../auth').withAuthLevel,
+  WRITE = 'write';
 
 /**
  * All routes go here.
@@ -52,11 +54,13 @@ function routes(router) {
   router.all('/', responses.methodNotAllowed({allow: ['get', 'post']}));
   router.all('/', responses.notAcceptable({accept: ['application/json']}));
   router.get('/', responses.listAsReferencedObjects);
+  router.post('/', withAuthLevel(WRITE));
   router.post('/', route.post);
 
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'delete']}));
   router.all('/:name', responses.notAcceptable({accept: ['application/json']}));
   router.get('/:name', responses.getRouteFromDB);
+  router.delete('/:name', withAuthLevel(WRITE)); // Write for un-scheduling
   router.delete('/:name', route.del);
 }
 

--- a/lib/routes/uris.js
+++ b/lib/routes/uris.js
@@ -8,8 +8,7 @@
 
 const responses = require('../responses'),
   controller = require('../services/uris'),
-  withAuthLevel = require('../auth').withAuthLevel,
-  WRITE = 'write';
+  { withAuthLevel, authLevels } = require('../auth');
 
 /**
  * @param {object} req
@@ -52,9 +51,9 @@ function routes(router) {
   router.all('/:name', responses.notAcceptable({accept: ['text/plain']}));
   router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', getUriFromReference);
-  router.put('/:name', withAuthLevel(WRITE));
+  router.put('/:name', withAuthLevel(authLevels.WRITE));
   router.put('/:name', putUriFromReference);
-  router.delete('/:name', withAuthLevel(WRITE)); // Delete is WRITE because unpublish
+  router.delete('/:name', withAuthLevel(authLevels.WRITE)); // Delete is WRITE because unpublish
   router.delete('/:name', deleteUriFromReference);
 }
 

--- a/lib/routes/uris.js
+++ b/lib/routes/uris.js
@@ -7,7 +7,9 @@
 'use strict';
 
 const responses = require('../responses'),
-  controller = require('../services/uris');
+  controller = require('../services/uris'),
+  withAuthLevel = require('../auth').withAuthLevel,
+  WRITE = 'write';
 
 /**
  * @param {object} req
@@ -50,7 +52,9 @@ function routes(router) {
   router.all('/:name', responses.notAcceptable({accept: ['text/plain']}));
   router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', getUriFromReference);
+  router.put('/:name', withAuthLevel(WRITE));
   router.put('/:name', putUriFromReference);
+  router.delete('/:name', withAuthLevel(WRITE)); // Delete is WRITE because unpublish
   router.delete('/:name', deleteUriFromReference);
 }
 

--- a/lib/routes/users.js
+++ b/lib/routes/users.js
@@ -8,7 +8,9 @@
 
 const _ = require('lodash'),
   responses = require('../responses'),
-  controller = require('../services/users');
+  controller = require('../services/users'),
+  withAuthLevel = require('../auth').withAuthLevel,
+  ADMIN = 'admin';
 
 /**
  * All routes go here.
@@ -40,6 +42,7 @@ function routes(router) {
   router.get('/', responses.list());
 
   // create new user
+  router.post('/', withAuthLevel(ADMIN));
   router.post('/', responses.denyReferenceAtRoot);
   router.post('/', route.post);
 
@@ -49,7 +52,9 @@ function routes(router) {
   router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', responses.getRouteFromDB);
   router.put('/:name', responses.denyReferenceAtRoot);
+  router.put('/:name', withAuthLevel(ADMIN));
   router.put('/:name', responses.putRouteFromDB);
+  router.delete('/:id', withAuthLevel(ADMIN));
   router.delete('/:id', responses.deleteRouteFromDB);
 }
 

--- a/lib/routes/users.js
+++ b/lib/routes/users.js
@@ -9,8 +9,7 @@
 const _ = require('lodash'),
   responses = require('../responses'),
   controller = require('../services/users'),
-  withAuthLevel = require('../auth').withAuthLevel,
-  ADMIN = 'admin';
+  { withAuthLevel, authLevels } = require('../auth');
 
 /**
  * All routes go here.
@@ -42,7 +41,7 @@ function routes(router) {
   router.get('/', responses.list());
 
   // create new user
-  router.post('/', withAuthLevel(ADMIN));
+  router.post('/', withAuthLevel(authLevels.ADMIN));
   router.post('/', responses.denyReferenceAtRoot);
   router.post('/', route.post);
 
@@ -52,9 +51,9 @@ function routes(router) {
   router.all('/:name', responses.denyTrailingSlashOnId);
   router.get('/:name', responses.getRouteFromDB);
   router.put('/:name', responses.denyReferenceAtRoot);
-  router.put('/:name', withAuthLevel(ADMIN));
+  router.put('/:name', withAuthLevel(authLevels.ADMIN));
   router.put('/:name', responses.putRouteFromDB);
-  router.delete('/:id', withAuthLevel(ADMIN));
+  router.delete('/:id', withAuthLevel(authLevels.ADMIN));
   router.delete('/:id', responses.deleteRouteFromDB);
 }
 

--- a/lib/routes/users.js
+++ b/lib/routes/users.js
@@ -27,9 +27,27 @@ let route = _.bindAll({
     responses.expectJSON(function () {
       return controller.post(req.uri, req.body, res.locals);
     }, res);
+  },
+  postAll(req, res) {
+    responses.expectJSON(function () {
+      return controller.postAll(req.uri, req.body);
+    }, res);
+  },
+  putAll(req, res) {
+    responses.expectJSON(function () {
+      return controller.putAll(req.uri, req.body);
+    }, res);
+  },
+  deleteAll(req, res) {
+    responses.expectJSON(function () {
+      return controller.deleteAll(req.uri);
+    }, res);
   }
 }, [
-  'post'
+  'post',
+  'postAll',
+  'putAll',
+  'deleteAll'
 ]);
 
 function routes(router) {
@@ -45,6 +63,13 @@ function routes(router) {
   router.post('/', responses.denyReferenceAtRoot);
   router.post('/', route.post);
 
+  // Interact with users across all sites in the Clay instance
+  // router.all('/all-sites', responses.methodNotAllowed({allow: ['put', 'post', 'delete']}));
+  router.all('/all-sites', withAuthLevel(authLevels.ADMIN))
+  router.post('/all-sites', route.postAll);
+  router.put('/all-sites/:id', route.putAll);
+  router.delete('/all-sites/:id', route.deleteAll);
+
   // get and update users
   router.all('/:name', responses.acceptJSONOnly);
   router.all('/:name', responses.methodNotAllowed({allow: ['get', 'put', 'delete']}));
@@ -55,6 +80,7 @@ function routes(router) {
   router.put('/:name', responses.putRouteFromDB);
   router.delete('/:id', withAuthLevel(authLevels.ADMIN));
   router.delete('/:id', responses.deleteRouteFromDB);
+
 }
 
 module.exports = routes;

--- a/lib/services/users.js
+++ b/lib/services/users.js
@@ -120,7 +120,7 @@ function templateUserId(uri, username, provider) {
  * @return {Promise}
  */
 function postAll(uri, data) {
-  let userId;
+  let { username, provider } = data, userId;
 
   // Validate data object
   validateUserObject(data);

--- a/lib/services/users.js
+++ b/lib/services/users.js
@@ -34,11 +34,10 @@ function decode(string) {
  * @returns {Promise}
  */
 function post(uri, data) {
-  let username = data.username,
-    provider = data.provider;
+  let { username, provider, auth } = data;
 
-  if (!username || !provider) {
-    throw new Error('Users require username and provider to be specified!');
+  if (!username || !provider || !auth) {
+    throw new Error('Users require username, provider and auth to be specified!');
   }
 
   uri += '/' + encode(username.toLowerCase(), provider);

--- a/lib/services/users.js
+++ b/lib/services/users.js
@@ -6,9 +6,72 @@
 
 'use strict';
 
-const db = require('./db'),
-  buf = require('./buffer');
+const _ = require('lodash'),
+  bluebird = require('bluebird'),
+  db = require('./db'),
+  buf = require('./buffer'),
+  sites = require('./sites');
 
+/**
+ * Validate a data object for specific values. Throw
+ * an error if a value is undefined.
+ *
+ * @param  {String} username
+ * @param  {String} provider
+ * @param  {String} auth
+ */
+function validateUserObject({ username, provider, auth }) {
+  if (!username || !provider || !auth) {
+    throw new Error('Users require username, provider and auth to be specified!');
+  }
+}
+
+/**
+ * Return a Promise for performing a put or delete of data
+ * to a specific user instance for all sites in a single
+ * Clay implementation.
+ *
+ * @param  {String} userId
+ * @param  {Object} data
+ * @param  {Function} data
+ * @return {Array}
+ */
+function constructSitesPromise(userId, data, fn) {
+  return _.map(sites.sites(), site => {
+    let userUri = `${site.host}${site.path}/users/${userId}`;
+
+    return fn(userUri, data);
+  });
+}
+
+/**
+ * Put user information to the DB
+ *
+ * @param  {String} userUri
+ * @param  {Object} data
+ * @return {Promise}
+ */
+function putUserData(userUri, data) {
+  return db.put(userUri, JSON.stringify(data)).then(function () {
+    data._ref = userUri;
+    return data;
+  })
+  .catch(e => {
+    return { error: e, _ref: userUri };
+  });
+}
+
+/**
+ * Delete a user's data
+ *
+ * @param  {String} userUri
+ * @return {Promise}
+ */
+function deleteUserData(userUri) {
+  return db.get(userUri)
+    .then(JSON.parse)
+    .then(oldData => db.del(userUri).return(oldData));
+}
 /**
  * encode username and provider to base64
  * @param {string} username
@@ -20,27 +83,14 @@ function encode(username, provider) {
 }
 
 /**
- * decode username and provider from base64
- * @param {string} string
- * @returns {string} username@provider
- */
-function decode(string) {
-  return buf.decode(string);
-}
-
-/**
  * @param {string} uri
  * @param {object} data
  * @returns {Promise}
  */
 function post(uri, data) {
-  let { username, provider, auth } = data;
+  validateUserObject(data);
 
-  if (!username || !provider || !auth) {
-    throw new Error('Users require username, provider and auth to be specified!');
-  }
-
-  uri += '/' + encode(username.toLowerCase(), provider);
+  uri = templateUserId(uri, username, provider);
 
   return db.put(uri, JSON.stringify(data)).then(function () {
     data._ref = uri;
@@ -48,7 +98,70 @@ function post(uri, data) {
   });
 }
 
+/**
+ * Create a uri for a user. Checks if there's a trailing slash on the
+ * uri and prunes it before constructing, just for safety. base64
+ * encodes the user id.
+ *
+ * @param  {String} uri
+ * @param  {String} username
+ * @param  {String} provider
+ * @return {String}
+ */
+function templateUserId(uri, username, provider) {
+  return `${uri}${uri.slice(-1) === '/' ? '' : '/'}${encode(username.toLowerCase(), provider)}`;
+}
+
+/**
+ * Creates new user instances instances across all sites
+ *
+ * @param  {String} uri
+ * @param  {Object} data
+ * @return {Promise}
+ */
+function postAll(uri, data) {
+  let userId;
+
+  // Validate data object
+  validateUserObject(data);
+  // Construct the userId once
+  userId = templateUserId('', username, provider);
+  // Return the resolved promises for user creation
+  return bluebird.all(constructSitesPromise(userId, data, putUserData));
+}
+
+/**
+ * Modifies user object at a specific ID across all sites
+ *
+ * @param  {String} uri
+ * @param  {Object} data
+ * @return {Promise}
+ */
+function putAll(uri, data) {
+  let userId;
+
+  // Validate data object
+  validateUserObject(data);
+  // Grab userID
+  userId = uri.split('/all-sites/')[1];
+  // Return the resolved promises for user modification
+  return bluebird.all(constructSitesPromise(userId, data, putUserData));
+}
+
+/**
+ * Delete a user instance across all sites
+ *
+ * @param  {String} uri
+ * @return {Promise}
+ */
+function deleteAll(uri) {
+  return bluebird.all(constructSitesPromise(uri.split('/all-sites/')[1], null, deleteUserData));
+}
+
 // outsiders can act on users
 module.exports.post = post;
+module.exports.postAll = postAll;
+module.exports.putAll = putAll;
+module.exports.deleteAll = deleteAll;
 module.exports.encode = encode;
-module.exports.decode = decode;
+module.exports.decode = buf.decode;

--- a/lib/services/users.test.js
+++ b/lib/services/users.test.js
@@ -48,13 +48,4 @@ describe(_.startCase(filename), function () {
     });
   });
 
-  describe('decode', function () {
-    const fn = lib[this.title];
-
-    it('decodes username and provider', function () {
-      var encoded = buf.encode('foo@bar');
-
-      expect(fn(encoded)).to.equal('foo@bar');
-    });
-  });
 });


### PR DESCRIPTION
_Updated 9/2_

First iteration of permissions in Amphora. 

**Two permissions levels:** 
- Admin
- Write

**Implementation Details**
- API Keys are assumed to be `admin` level
- Users need a `auth` property set, otherwise errors get thrown
- `401` response method added
- Authentication levels set on each route for `PUT`, `DELETE` and `POST`. At a minimum, `write` level access should be added
- a `users/all-sites` route added for creating/modifying/removing new users for each site with one request (`PUT`, `POST`, `DELETE)

**Further Changes Necessary**
- [ ] Test to 100% coverage once Kiln needs are confirmed