### PR TITLE
Request Route Params

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -222,8 +222,8 @@ function renderPage(uri, req, res) {
 
   // Add request route params and request queries
   // to the locals object
-  locals.reqParams = req.params;
-  locals.reqQuery = req.query;
+  locals.params = req.params;
+  locals.query = req.query;
 
   // look up page alias' component instance
   return getDBObject(uri)

--- a/lib/render.js
+++ b/lib/render.js
@@ -220,8 +220,10 @@ function renderPage(uri, req, res) {
     extension = getExtension(req),
     renderer = findRenderer(extension);
 
-  // Add request route params to the locals object
+  // Add request route params and request queries
+  // to the locals object
   locals.reqParams = req.params;
+  locals.reqQuery = req.query;
 
   // look up page alias' component instance
   return getDBObject(uri)

--- a/lib/render.js
+++ b/lib/render.js
@@ -220,6 +220,9 @@ function renderPage(uri, req, res) {
     extension = getExtension(req),
     renderer = findRenderer(extension);
 
+  // Add request route params to the locals object
+  locals.reqParams = req.params;
+
   // look up page alias' component instance
   return getDBObject(uri)
     .then(function (result) {


### PR DESCRIPTION
Adds the route params from `req.params` to the `locals` object.

Use case: pages who have one template for multiple routes which varies content based on the param value (i.e. section pages).