### PR TITLE
serialize and deserialize user data in sessions

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -122,16 +122,22 @@ function getCallbackUrl(site, provider) {
 }
 
 // serialize and deserialize users into the session
-/**
- * call callback with user data
- * @param {object} user
- * @param {function} done
- */
-function returnUser(user, done) {
-  done(null, user);
-}
-passport.serializeUser(returnUser);
-passport.deserializeUser(returnUser);
+// note: pull user data from the database,
+// so requests in the same session will get updated user data
+passport.serializeUser(function (user, done) {
+  done(null, users.encode(user.username.toLowerCase(), user.provider));
+});
+
+passport.deserializeUser(function (uid, done) {
+  db.get(`/users/${uid}`)
+    .then(JSON.parse)
+    .then(function (user) {
+      done(null, user);
+    })
+    .catch(function (e) {
+      done(e);
+    });
+});
 
 /**
  * create/authenticate against a clay user
@@ -546,7 +552,6 @@ module.exports.isProtectedRoute = isProtectedRoute;
 module.exports.isAuthenticated = isAuthenticated;
 module.exports.getCallbackUrl = getCallbackUrl;
 module.exports.getPathOrBase = getPathOrBase;
-module.exports.returnUser = returnUser;
 module.exports.verify = verify;
 module.exports.verifyLdap = verifyLdap;
 module.exports.apiCallback = apiCallback;

--- a/lib/auth.test.js
+++ b/lib/auth.test.js
@@ -114,18 +114,6 @@ describe(_.startCase(filename), function () {
     });
   });
 
-  describe('returnUser', function () {
-    const fn = lib[this.title];
-
-    it('returns whatever is passed to it', function (done) {
-      fn('hi', function (err, data) {
-        expect(err).to.equal(null);
-        expect(data).to.equal('hi');
-        done();
-      });
-    });
-  });
-
   describe('verify', function () {
     const fn = lib[this.title],
       siteStub = {


### PR DESCRIPTION
* uses the key, fetches user data from the db every time
* this allows authenticating and deauthenticating without forcing the user to re-login
* this means smaller session records, which is good
* this requires all current sessions to be wiped, which is fine since we need to do that anyway to release amphora 4.x