### PR TITLE
Don't swallow errors in HTTP responses

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -152,6 +152,8 @@ function notImplemented(req, res) {
   const code = 501,
     message = 'Not Implemented';
 
+  log('error', new Error(message));
+
   sendDefaultResponseForCode(code, message, res);
 }
 
@@ -172,6 +174,7 @@ function methodNotAllowed(options) {
     } else {
       code = 405;
       message = 'Method ' + method + ' not allowed';
+      log('error', new Error(message));
       res.set('Allow', allowed.join(', ').toUpperCase());
       sendDefaultResponseForCode(code, message, res, options);
     }
@@ -195,6 +198,7 @@ function notAcceptable(options) {
     } else {
       code = 406;
       message = req.get('Accept') + ' not acceptable';
+      log('error', new Error(message));
       res.set('Accept', acceptableTypes.join(', ').toLowerCase());
       sendDefaultResponseForCode(code, message, res, options);
     }
@@ -270,7 +274,9 @@ function onlyCachePublished(req, res, next) {
  * @param {object} res
  */
 function notFound(err, res) {
-  if (!(err instanceof Error) && err) {
+  if (err instanceof Error) {
+    log('error', err);
+  } else {
     res = err;
   }
 
@@ -290,7 +296,7 @@ function notFound(err, res) {
  */
 function serverError(err, res) {
   // error is required to be logged
-  log('error', err.message);
+  log('error', err);
 
   const message = err.message || 'Server Error', // completely hide these messages from outside
     code = 500;
@@ -318,6 +324,7 @@ function unauthorized(res) {
  * @param {object} res
  */
 function clientError(err, res) {
+  log('error', err);
   // They know it's a 400 already, we don't need to repeat the fact that its an error.
   const message = removePrefix(err.message, ':'),
     code = 400;


### PR DESCRIPTION
log them to the console

For example, it's nice to know what wasn't found rather than getting just a 404 or `Cannot GET`:

![screen shot 2017-10-04 at 5 00 01 pm](https://user-images.githubusercontent.com/4691093/31199647-0d934c8c-a926-11e7-821b-2b3b79d2a9e7.jpg)

Theoretically, we'd also get a stack trace, but not seeing them with the new pino setup.