### PR TITLE
Rename Bootstrap Property

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -332,8 +332,8 @@ function skipBootstrap() {
   return bluebird.resolve();
 }
 
-module.exports = function (skip) {
-  return skip ? skipBootstrap() : bootrapSitesAndComponents();
+module.exports = function (skip = true) {
+  return skip ? bootrapSitesAndComponents() : skipBootstrap();
 };
 
 module.exports.bootstrapPath = bootstrapPath;

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -332,8 +332,8 @@ function skipBootstrap() {
   return bluebird.resolve();
 }
 
-module.exports = function (skip = true) {
-  return skip ? bootrapSitesAndComponents() : skipBootstrap();
+module.exports = function (runBootstrap = true) {
+  return runBootstrap ? bootrapSitesAndComponents() : skipBootstrap();
 };
 
 module.exports.bootstrapPath = bootstrapPath;

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -75,15 +75,8 @@ describe(_.startCase(filename), function () {
       return fn();
     });
 
-    it('skips boostrapping if the `skip` bool is true', function () {
-      return fn(true)
-        .then(function () {
-          sinon.assert.calledWith(fakeLog,'info', 'Skipping bootstrapping sites and components');
-        });
-    });
-
-    it('skips boostrapping if the `skip` bool is true', function () {
-      return fn(true)
+    it('skips bootstrapping if the `skip` bool is false', function () {
+      return fn(false)
         .then(function () {
           sinon.assert.calledWith(fakeLog,'info', 'Skipping bootstrapping sites and components');
         });

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -75,7 +75,7 @@ describe(_.startCase(filename), function () {
       return fn();
     });
 
-    it('skips bootstrapping if the `skip` bool is false', function () {
+    it('skips running the bootstrap process if the `runBootstrap` bool is false', function () {
       return fn(false)
         .then(function () {
           sinon.assert.calledWith(fakeLog,'info', 'Skipping bootstrapping sites and components');

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -14,11 +14,15 @@ bluebird.config({
 /**
  * optionally pass in an express app, templating engines, and/or providers
  * note: if no providers are passed in, amphora doesn't protect routes
- * @param {object} [options]
- * @param {array} [options.providers]
- * @param {object} [options.app]
- * @param {object} [options.engines]
- * @param {object} [options.sessionStore]
+ * @param {Object}  [options]
+ * @param {Array}   [options.providers]
+ * @param {Object}  [options.app]
+ * @param {Object}  [options.sessionStore]
+ * @param {Object}  [options.renderers]
+ * @param {Array}   [options.plugins]
+ * @param {Array}   [options.env]
+ * @param {Boolean} [options.bootstrap]
+ * @param {Object}  [options.cacheControl]
  * @returns {Promise}
  */
 module.exports = function (options = {}) {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -3,7 +3,7 @@
 const bluebird = require('bluebird'),
   express = require('express'),
   routes = require('./routes'),
-  bootstrap = require('./bootstrap'),
+  internalBootstrap = require('./bootstrap'),
   render = require('./render'),
   amphoraPlugins = require('./plugins');
 
@@ -30,7 +30,7 @@ module.exports = function (options = {}) {
       plugins = [],
       env = [],
       cacheControl = {},
-      skipBootstrap = false
+      bootstrap = true
     } = options, router;
   // TODO: DOCUMENT RENDERERS, ENV, PLUGINS, AND CACHE CONTROL
 
@@ -49,7 +49,7 @@ module.exports = function (options = {}) {
   }
 
   // look for bootstraps in components
-  return bootstrap(skipBootstrap).then(function () {
+  return internalBootstrap(bootstrap).then(function () {
     return router;
   });
 };


### PR DESCRIPTION
Renaming from `skipBootstrap` to `bootstrap`. Hasn't been released yet, so not a breaking change