### PR TITLE
Bug Fix: Bootstrapping Error

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -299,21 +299,22 @@ function bootrapSitesAndComponents() {
   return highland(sitesArray)
     .flatMap(site => {
       return highland(
-        bootstrapPath(site.dir, site)
+        bootstrapComponents(site)
           .then(function () {
             return site;
           })
           .catch(function () {
-            log('debug', `No bootstrap file found for site: ${site.slug}`);
+            log('debug', `Errors bootstrapping components for site: ${site.slug}`);
             return site;
           })
       );
     })
     .flatMap(site => {
       return highland(
-        bootstrapComponents(site)
+        bootstrapPath(site.dir, site)
           .catch(function () {
-            log('debug', `Errors bootstrapping components for site: ${site.slug}`);
+            log('debug', `No bootstrap file found for site: ${site.slug}`);
+            return site;
           })
       );
     })


### PR DESCRIPTION
Before streaming the boostrapping, components were bootstrapped and then the site.

Breaking this assumption is bad and doesn't allow sites to override component bootstraps.

Evidence of how it was before: https://github.com/clay/amphora/blob/821114ccbbecb1626c45d0a25a23434caf24a997/lib/bootstrap.js#L268-L274