### PR TITLE
Exclude components using query parameter

### DIFF
--- a/lib/services/composer.js
+++ b/lib/services/composer.js
@@ -7,6 +7,48 @@ const _ = require('lodash'),
   mapLayoutToPageData = require('../utils/layout-to-page-data'),
   referenceProperty = '_ref';
 
+
+/**
+ * Enables us to exclude certain components based on query parameter.
+ *
+ * Returns a function that can filter reference objects
+ * based on `locals`.
+ *
+ * `article` matches `/components/article/instances/foo` as well as `/components/layout/instances/article`,
+ * but `/components/article/instances/foo` matches only `/components/article/instances/foo`
+ *
+ * Uses `locals.query[locals.site.excludeKey]` as a string or array of strings used to filter
+ * using `String.protototype.includes`.
+ *
+ * Does no filtering if `excludeUsingQueryParam` is not set in the site config.
+ *
+ * @param {Object} [locals]
+ * @param {Object} [locals.site]
+ * @param {string|string[]} [locals.site.excludeUsingQueryParam] name of query parameter used to exclude components
+ * @param {Object} [locals.query]
+ * @returns {Function}
+ */
+function excludeComponents(locals) {
+  if (!locals || !locals.site || !locals.site.excludeUsingQueryParam || !locals.query || !locals.query[locals.site.excludeUsingQueryParam]) {
+    return () => true;
+  }
+
+  const excludeKey = locals.site.excludeUsingQueryParam,
+    exclude = locals.query[excludeKey];
+
+  return function filter(referenceObject) {
+    const ref = referenceObject[referenceProperty];
+
+    if (typeof exclude === 'string') {
+      return !ref.includes(exclude);
+    } else if (Array.isArray(exclude)) {
+      return !exclude.some(excludeStr => ref.includes(excludeStr));
+    } else {
+      return true;
+    }
+  };
+}
+
 /**
  * Compose a component, recursively filling in all component references with
  * instance data.
@@ -18,22 +60,24 @@ const _ = require('lodash'),
 function resolveComponentReferences(data, locals, filter = referenceProperty) {
   const referenceObjects = references.listDeepObjects(data, filter);
 
-  return bluebird.all(referenceObjects).each(function (referenceObject) {
+  return bluebird.all(referenceObjects)
+    .filter(excludeComponents(locals))
+    .each(function (referenceObject) {
+      return components.get(referenceObject[referenceProperty], locals)
+        .then(function (obj) {
+          // the thing we got back might have its own references
+          return resolveComponentReferences(obj, locals, filter).finally(function () {
+            _.assign(referenceObject, _.omit(obj, referenceProperty));
+          }).catch(function (error) {
+            // add additional information to the error message
+            const wrappedError = new Error(error.message + ' within ' + referenceObject[referenceProperty]);
 
-    return components.get(referenceObject[referenceProperty], locals)
-      .then(function (obj) {
-        // the thing we got back might have its own references
-        return resolveComponentReferences(obj, locals, filter).finally(function () {
-          _.assign(referenceObject, _.omit(obj, referenceProperty));
-        }).catch(function (error) {
-          // add additional information to the error message
-          const wrappedError = new Error(error.message + ' within ' + referenceObject[referenceProperty]);
-
-          wrappedError.name = error.name;
-          throw wrappedError;
+            wrappedError.name = error.name;
+            throw wrappedError;
+          });
         });
-      });
-  }).return(data);
+    })
+    .return(data);
 }
 
 /**

--- a/lib/services/composer.test.js
+++ b/lib/services/composer.test.js
@@ -92,6 +92,45 @@ describe(_.startCase(filename), function () {
       });
     });
 
+    it('excludes references by query parameter', () => {
+      const data = {
+          a: [
+            {_ref: '/c/1'},
+            {_ref: '/c/foo'},
+          ],
+          c: {d: [
+            {_ref: '/foo/e'},
+            {_ref: '/bar/1'},
+            {_ref: '/baz/1'},
+          ]}
+        },
+        locals = {
+          query: {_exclude: ['foo', 'bar']},
+          site: {
+            excludeUsingQueryParam: '_exclude'
+          }
+        },
+        dummy = 'dummy-data';
+
+
+      components.get.returns(bluebird.resolve({dummy}));
+
+      return fn(data, locals).then(result => {
+        expect(result).to.deep.equal({
+          a: [
+            {_ref: '/c/1', dummy},
+            {_ref: '/c/foo'},
+          ],
+          c: {d: [
+            {_ref: '/foo/e'},
+            {_ref: '/bar/1'},
+            {_ref: '/baz/1', dummy},
+          ]}
+        });
+      });
+
+    });
+
     it('adds additional reference information to any errors that occur', function (done) {
       const data = {
           a: {_ref: '/c/b'},


### PR DESCRIPTION
Fix #452 

Add ability to exclude components from
rendering using query parameters. This can be
helpful for testing page performance with different
combinations of components.

To use this feature:

- Add this key to your site config: `excludeUsingQueryParam`
and set its value to the name of the query parameter. For example:
`excludeUsingQueryParam: _exclude`.

- Restart Clay

- In a browser, request a page, using the new URL parameter.
For example, if the parameter is named `_exclude` and you want
to exclude the `block-quote` component, you can use a URL that ends with
`?_exclude=/block-quote/`. The matching is done using
String.prototype.includes, so you can match against the entire ref
for components or just part of the ref. You can also pass the parameter
multiple times. This search string excludes all `block-quote`s and a
single instance of `clay-paragraph`
`?_exclude=/block-quote/&_exclude=/clay-paragraph/instances/cj8nij4010000ys1u6yz6e48x`.