### PR TITLE
Pass missing auth level error to client

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -49,12 +49,18 @@ function checkAuthLevel(userLevel, requiredLevel) {
  */
 function withAuthLevel(requiredLevel) {
   return function (req, res, next) {
-    if (checkAuthLevel(_.get(req, 'user.auth', ''), requiredLevel)) {
-      // If the user exists and meets the level requirement, let the request proceed
-      next();
-    } else {
-      // None of the above, we need to error
-      responses.unauthorized(res);
+    var userLevel = _.get(req, 'user.auth', '');
+
+    try {
+      if (checkAuthLevel(userLevel, requiredLevel)) {
+        // If the user exists and meets the level requirement, let the request proceed
+        next();
+      } else {
+        // None of the above, we need to error
+        responses.unauthorized(res);
+      }
+    } catch (e) {
+      responses.serverError(e, res);
     }
   };
 }

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -135,12 +135,16 @@ function sendTextErrorCode(code, message, res) {
  * @param {object} extras
  */
 function sendDefaultResponseForCode(code, message, res, extras) {
-  res.status(code).format({
-    json: sendJSONErrorCode(code, message, res, extras),
-    html: sendHTMLErrorCode(code, message, res),
-    text: sendTextErrorCode(code, message, res),
-    default: sendDefaultErrorCode(code, res)
-  });
+  res.statusMessage = message;
+  res
+    .status(code)
+    .format({
+      json: sendJSONErrorCode(code, message, res, extras),
+      html: sendHTMLErrorCode(code, message, res),
+      text: sendTextErrorCode(code, message, res),
+      default: sendDefaultErrorCode(code, res)
+    })
+    .end();
 }
 
 /**
@@ -290,7 +294,7 @@ function notFound(err, res) {
  */
 function serverError(err, res) {
   // error is required to be logged
-  log('error', err.message);
+  log('error', `${err.message}`);
 
   const message = err.message || 'Server Error', // completely hide these messages from outside
     code = 500;


### PR DESCRIPTION
*Problem*: if there an auth level is not set for the user account, an error is thrown. This occurs if the user was bootstrapped incorrectly. The client will get a `500: Internal Server Error` error, which is not helpful, especially if the developer does not have access to Amphora logs

*Solution*:
- update `responses.serverError()` to send a custom [`response.statusMessage`](https://nodejs.org/dist/latest-v6.x/docs/api/http.html#http_response_statusmessage)
- catch the error so that `.serverError()` can be called