### PR TITLE
renderer models

### DIFF
--- a/lib/control.js
+++ b/lib/control.js
@@ -67,6 +67,9 @@ function reportMemoryLeak(fn, cache) {
 
 /**
  * Memoize, but warn if the target is not suitable for memoization
+ *
+ * Use this if you want memory leak logging.
+ *
  * @param {function} fn
  * @returns {function}
  */

--- a/lib/files.js
+++ b/lib/files.js
@@ -250,12 +250,19 @@ function setRequire(value) {
  * NOTE: This includes local components as well as npm components.
  *
  * @param {string} name
+ * @param {string} [prefix]
  * @returns {object|false}
  */
-function getComponentModule(name) {
-  let componentPath = module.exports.getComponentPath(name);
+function getComponentModule(name, prefix) {
+  var componentPath;
 
-  return componentPath && tryRequire(componentPath + '/model');
+  if (prefix === 'html') {
+    return false;
+  }
+
+  componentPath = module.exports.getComponentPath(name);
+
+  return componentPath && tryRequire(`${componentPath}/${prefix ? `${prefix}.` : ''}model`);
 }
 
 /**
@@ -297,7 +304,7 @@ exports.getFolders = control.memoize(getFolders);
 exports.fileExists = control.memoize(fileExists);
 exports.getComponents = control.memoize(getComponents);
 exports.getComponentPath = control.memoize(getComponentPath);
-exports.getComponentModule = control.memoize(getComponentModule);
+exports.getComponentModule = _.memoize(getComponentModule, (name, prefix) => `${name}${prefix ? `|${prefix}` : ''}`);
 exports.getComponentPackage = control.memoize(getComponentPackage);
 exports.isDirectory = control.memoize(isDirectory);
 exports.tryRequire = control.memoize(tryRequire);

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -292,6 +292,27 @@ describe(_.startCase(filename), function () {
 
       expect(fn(name)).to.equal(result);
     });
+
+    it('handles renderer model.js path', function () {
+      const name = 'some name',
+        path = 'some path',
+        prefix = 'foobar',
+        result = 'some result';
+
+      lib.getComponentPath.returns(path);
+      req.resolve.withArgs(`${path}/${prefix}.model`).returns(`${path}/${prefix}.model`);
+      req.withArgs(`${path}/${prefix}.model`).returns(result);
+
+      expect(fn(name, prefix)).to.equal(result);
+    });
+
+    it('returns undefined if the prefix is html', function () {
+      const name = 'some name',
+        prefix = 'html';
+
+      expect(fn(name, prefix)).to.be.false;
+      sinon.assert.notCalled(lib.getComponentPath);
+    });
   });
 
   describe('getComponentPackage', function () {

--- a/lib/files.test.js
+++ b/lib/files.test.js
@@ -306,7 +306,7 @@ describe(_.startCase(filename), function () {
       expect(fn(name, prefix)).to.equal(result);
     });
 
-    it('returns undefined if the prefix is html', function () {
+    it('returns false if the prefix is html', function () {
       const name = 'some name',
         prefix = 'html';
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -222,10 +222,11 @@ function renderPage(uri, req, res) {
     extension = getExtension(req),
     renderer = findRenderer(extension);
 
-  // Add request route params and request queries
-  // to the locals object
+  // Add request route params, request query params
+  // and the request extension to the locals object
   locals.params = req.params;
   locals.query = req.query;
+  locals.extension = extension;
 
   // look up page alias' component instance
   return getDBObject(uri)
@@ -234,7 +235,7 @@ function renderPage(uri, req, res) {
         layoutComponentName = utils.getName(layoutReference),
         pageData = references.omitPageConfiguration(result);
 
-      return components.get(layoutReference)
+      return components.get(layoutReference, locals)
         .then(mapLayoutToPageData.bind(this, pageData))
         .then(function (result) {
           const options = {

--- a/lib/render.js
+++ b/lib/render.js
@@ -190,6 +190,12 @@ function renderComponent(req, res, options) {
     locals = res.locals,
     options = options || {};
 
+  // Add request route params, request query params
+  // and the request extension to the locals object
+  locals.params = req.params;
+  locals.query = req.query;
+  locals.extension = extension;
+
   return components.get(uri, locals)
     .then(data => {
       options.version = options.version || uri.split('@')[1];

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -85,7 +85,7 @@ function get(uri, locals) {
   }
 
   if (renderModel) {
-    promise.then(function (data) {
+    promise = promise.then(function (data) {
       return renderModel(uri, data, locals);
     });
   }

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -53,7 +53,9 @@ function get(uri, locals) {
   let promise,
     name = utils.getName(uri),
     componentModule = name && files.getComponentModule(name),
-    callComponentHooks = _.get(locals, 'componenthooks') !== 'false';
+    callComponentHooks = _.get(locals, 'componenthooks') !== 'false',
+    reqExtension = _.get(locals, 'extension'),
+    renderModel = reqExtension && files.getComponentModule(name, reqExtension);
 
   // check for model.render() (plus no componenthooks flag)
   if (componentModule && _.isFunction(componentModule.render) && callComponentHooks) {
@@ -80,6 +82,12 @@ function get(uri, locals) {
     }).timeout(timeoutLimit, `Component module GET exceeded ${timeoutLimit}ms: ${uri}`);
   } else {
     promise = db.get(uri).then(JSON.parse).then(upgrade.init(uri, locals)); // Run an upgrade!
+  }
+
+  if (renderModel) {
+    promise.then(function (data) {
+      return renderModel(uri, data, locals);
+    });
   }
 
   return promise.then(function (data) {

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -374,6 +374,20 @@ describe(_.startCase(filename), function () {
       });
     });
 
+    it('gets using renderer model', function () {
+      const ref = 'domain.com/path/components/whatever',
+        renderSpy = sinon.stub();
+
+      db.get.returns(Promise.resolve(JSON.stringify({a: 'b'})));
+      upgrade.init.returns(Promise.resolve({a: 'b'}));
+      renderSpy.returns({ a: 'b' });
+      files.getComponentModule.returns(renderSpy);
+      return fn(ref, { extension: 'foobar' }).then(function () {
+        sinon.assert.called(files.getComponentModule);
+        sinon.assert.calledWith(renderSpy, ref);
+      });
+    });
+
     it('blocks component model returning non-object', function (done) {
       const ref = 'domain.com/path/components/whatever',
         renderSpy = sinon.stub();

--- a/lib/services/schedule.test.js
+++ b/lib/services/schedule.test.js
@@ -64,7 +64,6 @@ describe(_.startCase(filename), function () {
       db.batch.returns(bluebird.resolve({}));
 
       return fn(ref, data).then(function () {
-        console.log('\n\n\n', JSON.stringify(db.batch.args), '\n\n\n\n');
         sinon.assert.calledWith(db.batch, [{
           key: 'domain/schedule/YWJjL3BhZ2VzL2RlZg==',
           type: 'put',


### PR DESCRIPTION
## Problem
The aim of this PR is to address rendering content for distributed networks (Apple News, RSS, AMP, etc). Clay is a system who is geared primarily towards serving/editing component data via a web browser, but this creates constraints on how data is saved/rendered when trying to use the same components for distributed networks.

## Solution
This problem was initially patched by making Amphora focused on JSON as the primary data delivery format and allowing renderers to handle the compilation of that data into whatever form is necessary. This initial approach worked well for serving HTML, but created one big issue: data is still composed in the same tree no matter what renderer you choose to use. Essentially, this means that if you need to format data deep in the tree, you have to write code in your renderer to traverse the tree, modify the data and either preserve or completely destroy the tree as Amphora understands it.

While we're not going to change how the tree is composed, what we can do is allow components to translate their own data into a format more friendly to the renderer as it leaves the DB. This means that component directories can now store a `<RENDERER_EXTENSION>.model.js` which will invoked _AFTER_ the default `model.js` file.

```
GET www.mysite.com/components/foo/instances/bar.rss

1. `foo/model.js` runs
2. Amphora checks for an `rss.model.js`
3. If found, Amphora `foo/rss.model.js` runs
4. Once data is composed, it's passed to the renderer for final compilation
```
From there a renderer can still do whatever it needs to do to handle the data. It can look for a template to handle formatting of the data, it can further transform the data and then respond with JSON. The flow is up to the author of the renderer.

## Caveat
The `html` extension is ignored. i.e. there are no `html.model.js` affordances. The reasoning goes back to Clay's primary outlet being the web browser. Your regular `model.js` should do everything it needs to do for formatting the data in the way Kiln will edit the component, these additional `<renderer>.model.js` files are for non-html renderers only.

## Renderer Model.js Files
These files should closely mirror the regular `model.js` files, except they only need to export one function by default.

```
module.exports = function (ref, data, locals) {

// Transform data
// Return a Promise which resolves data 
// or an object directly

return data;
};
```

## Changes

- Runs components through a renderer-specific `<RENDERER_EXTENSION>.model.js` file
- Updates `getComponentModule` to accept a `prefix` argument for model.js files
- Updates memoization for the `getComponentModule` file to support multiple arguments
- Adds the request extension to `locals`. When requesting straight data this value id `undefined`, only when requesting a page where a renderer would affect output
- Bugfix: Adds `locals` to the `get` of the layout data when rendering a page. This means the model.js file will actually run for a layout
- Remove bad `console.log` artifact