### PR TITLE
CORS: Options Requests

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -428,7 +428,7 @@ function compileTemplate(filename) {
  */
 function protectRoutes(site) {
   return function (req, res, next) {
-    if (module.exports.isProtectedRoute(req)) { // allow mocking of these for testing
+    if (req.method !== 'OPTIONS' && module.exports.isProtectedRoute(req)) { // allow mocking of these for testing
       module.exports.isAuthenticated(site)(req, res, next);
     } else {
       next();

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -19,7 +19,7 @@ const _ = require('lodash'),
   plugins = require('./plugins'),
   cors = {
     origins: '*',
-    methods: ['GET', 'POST', 'PUT', 'DELETE'].join(','),
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'].join(','),
     headers: ['Accept', 'Accept-Encoding', 'Authorization', 'Content-Type', 'Host', 'Referer', 'Origin', 'User-Agent',
       'X-Forwarded-For', 'X-Forwarded-Host', 'X-Forwarded-Proto'].join(',')
   };

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -58,7 +58,7 @@ describe(_.startCase(filename), function () {
 
       test({method: 'OPTIONS', headers: {}}, res);
 
-      sinon.assert.calledWith(spy, 'Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE');
+      sinon.assert.calledWith(spy, 'Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
       sinon.assert.calledWith(spy, 'Access-Control-Allow-Headers', sinon.match.string);
     });
   });


### PR DESCRIPTION
Some http clients execute an `OPTIONS` request as a pre-flight for CORS requests. Because of this, `OPTIONS` requests have to return `OPTIONS` in the `Access-Control-Allow-Methods` header to these requests.

Also, when performing the `OPTIONS` request we have to make sure to not check for authorization. 