### PR TITLE
Site Config Checks

### DIFF
--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -3,6 +3,9 @@
 const _ = require('lodash'),
   files = require('../files'),
   path = require('path');
+var log = require('./logger').setup({
+  file: __filename
+});
 
 /**
  * Normalize path to never end with a slash.
@@ -53,6 +56,11 @@ function getSites() {
       siteConfig = files.getYaml(path.join(dir, 'config')),
       localConfig = files.getYaml(path.join(dir, 'local'));
 
+    if (!siteConfig) {
+      log('warn', `No site config file found for site '${site}', please make sure one is included`);
+      return;
+    }
+
     // apply locals over site config
     if (localConfig) {
       _.assign(siteConfig, localConfig);
@@ -69,6 +77,11 @@ function getSites() {
     // check to make sure sites have default properties
     if (!siteConfig.host) {
       throw new Error('Missing host in site config');
+    }
+
+    if (!siteConfig.protocol) {
+      log('warn', `A protocol property ('http' or 'https') was not found for site '${site}', it will default to 'http'`);
+      siteConfig.protocol = 'http';
     }
 
     // add site config to the sites map
@@ -126,3 +139,4 @@ module.exports.getSiteFromPrefix = getSiteFromPrefix;
 // exported for tests
 module.exports.normalizePath = normalizePath;
 module.exports.normalizeDirectory = normalizeDirectory;
+module.exports.setLog = (fakeLogger) => { log = fakeLogger; };

--- a/lib/services/sites.test.js
+++ b/lib/services/sites.test.js
@@ -9,7 +9,7 @@ const _ = require('lodash'),
   lib = require('./' + filename);
 
 describe(_.startCase(filename), function () {
-  let sandbox,
+  let sandbox, logSpy,
     mockSites = {
       a: {
         dir: 'z/a',
@@ -18,7 +18,8 @@ describe(_.startCase(filename), function () {
         path: '/e',
         prefix: 'd/e',
         assetDir: 'public',
-        assetPath: '/e'
+        assetPath: '/e',
+        protocol: 'http'
       },
       b: {
         dir: 'z/b',
@@ -27,7 +28,8 @@ describe(_.startCase(filename), function () {
         path: '/e',
         prefix: 'd/e',
         assetDir: 'public',
-        assetPath: '/e'
+        assetPath: '/e',
+        protocol: 'http'
       },
       c: {
         dir: 'z/c',
@@ -36,7 +38,8 @@ describe(_.startCase(filename), function () {
         path: '/i/j',
         prefix: 'h/i/j',
         assetDir: 'public',
-        assetPath: '/i/j'
+        assetPath: '/i/j',
+        protocol: 'http'
       }
     },
     mockSitesWithoutPaths = {
@@ -47,7 +50,8 @@ describe(_.startCase(filename), function () {
         path: '',
         prefix: 'd',
         assetDir: 'public',
-        assetPath: ''
+        assetPath: '',
+        protocol: 'http'
       },
       b: {
         dir: 'z/b',
@@ -56,7 +60,8 @@ describe(_.startCase(filename), function () {
         path: '',
         prefix: 'd',
         assetDir: 'public',
-        assetPath: ''
+        assetPath: '',
+        protocol: 'http'
       }
     };
 
@@ -71,7 +76,8 @@ describe(_.startCase(filename), function () {
       slug: 'c',
       host: 'd',
       path: 'e',
-      assetPath: 'e'
+      assetPath: 'e',
+      protocol: 'http'
     };
   }
 
@@ -82,8 +88,20 @@ describe(_.startCase(filename), function () {
     };
   }
 
+  function getMockSiteWithoutProtocol() {
+    return {
+      slug: 'c',
+      host: 'd',
+      path: 'e',
+      assetPath: 'e'
+    };
+  }
+
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    logSpy = sandbox.spy();
+
+    lib.setLog(logSpy);
     sandbox.stub(fs, 'readFileSync');
     sandbox.stub(path, 'resolve');
     sandbox.stub(files, 'getFolders');
@@ -113,7 +131,6 @@ describe(_.startCase(filename), function () {
         prefix: 'h/i/j'
       });
 
-
       expect(fn()).to.deep.equal(mockSites);
     });
 
@@ -134,6 +151,36 @@ describe(_.startCase(filename), function () {
       files.getYaml.onSecondCall().returns(getMockBadSite());
 
       expect(function () { fn(); }).to.throw();
+    });
+
+    it('logs a warning and does not attach a site with no config file', function () {
+      var sites;
+
+      files.getFolders.returns(['a']);
+      path.resolve.returns('z');
+      files.getYaml.onFirstCall().returns(null);
+      files.getYaml.onSecondCall().returns({});
+
+      sites = fn();
+      sinon.assert.calledWith(logSpy, 'warn', 'No site config file found for site \'a\', please make sure one is included');
+      expect(sites).to.eql({});
+    });
+
+    it('adds in the `protocol` property and logs warning if it is not on the config', function () {
+      files.getFolders.returns(['a', 'b', 'c']);
+      path.resolve.returns('z');
+      files.getYaml.onFirstCall().returns(getMockSiteWithoutProtocol());
+      files.getYaml.onSecondCall().returns(getMockSiteWithoutProtocol());
+      files.getYaml.onThirdCall().returns(getMockSiteWithoutProtocol());
+      files.getYaml.onCall(4).returns({
+        assetPath: '/i/j',
+        host: 'h',
+        path: '/i/j',
+        prefix: 'h/i/j'
+      });
+
+      expect(fn()).to.deep.equal(mockSites);
+      sinon.assert.calledWith(logSpy, 'warn', 'A protocol property (\'http\' or \'https\') was not found for site \'a\', it will default to \'http\'');
     });
   });
 


### PR DESCRIPTION
- Checks for presence of the site config, logs a warning if one does not exist (https://github.com/clay/amphora/issues/516)
- Checks for presence of `protocol` property, logs a warning and assigns default if one does not exist (https://github.com/clay/amphora/issues/517)