### PR TITLE
Swaps in new clayutils functions

### DIFF
--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -18,7 +18,7 @@ const _ = require('lodash'),
   references = require('./references'),
   bluebird = require('bluebird'),
   upgrade = require('./upgrade'),
-  { getComponentName } = require('clayutils'),
+  { getComponentName, replaceVersion } = require('clayutils'),
   referenceProperty = '_ref',
   timeoutGetCoefficient = 2,
   timeoutPutCoefficient = 5;
@@ -112,7 +112,7 @@ function list() {
 function putLatest(uri, data) {
   data = JSON.stringify(data);
   return [
-    { type: 'put', key: references.replaceVersion(uri), value: data }
+    { type: 'put', key: replaceVersion(uri), value: data }
   ];
 }
 
@@ -125,7 +125,7 @@ function putLatest(uri, data) {
 function putPublished(uri, data) {
   data = JSON.stringify(data);
   return [
-    { type: 'put', key: references.replaceVersion(uri, 'published'), value: data }
+    { type: 'put', key: replaceVersion(uri, 'published'), value: data }
   ];
 }
 
@@ -139,7 +139,7 @@ function putPublished(uri, data) {
 function putTag(uri, data, tag) {
   data = JSON.stringify(data);
   return [
-    { type: 'put', key: references.replaceVersion(uri, tag), value: data }
+    { type: 'put', key: replaceVersion(uri, tag), value: data }
   ];
 }
 
@@ -354,7 +354,7 @@ function publish(uri, data, locals) {
     return cascadingPut(uri, data, locals);
   }
 
-  return get(references.replaceVersion(uri), locals)
+  return get(replaceVersion(uri), locals)
     .then(latestData => composer.resolveComponentReferences(latestData, locals, filterBaseInstanceReferences))
     .then(versionedData => cascadingPut(uri, versionedData, locals));
 }

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -298,7 +298,7 @@ function publish(uri, data, locals) {
 function create(uri, data, locals) {
   const layoutReference = data && data.layout,
     pageData = data && references.omitPageConfiguration(data),
-    prefix = uri.substr(0, uri.indexOf('/_pages')),
+    prefix = getPrefix(uri),
     site = getSite(prefix, locals),
     pageReference = `${prefix}/_pages/${uid.get()}`;
 

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -15,7 +15,7 @@ const _ = require('lodash'),
   siteService = require('./sites'),
   timer = require('../timer'),
   uid = require('../uid'),
-  { getComponentName } = require('clayutils'),
+  { getComponentName, replaceVersion, getPrefix } = require('clayutils'),
   publishService = require('./publish'),
   plugins = require('../plugins'),
   timeoutPublishCoefficient = 5;
@@ -135,16 +135,16 @@ function applyBatch(site) {
  * @returns {object}
  */
 function replacePageReferenceVersions(data, version) {
-  const replaceVersion = _.partial(references.replaceVersion, _, version);
+  const replace = _.partial(replaceVersion, _, version);
 
   return _.mapValues(data, function (value, key) {
     let result;
 
     if (references.isUri(value)) {
-      result = replaceVersion(value);
+      result = replace(value);
     } else if (_.isArray(value) && key !== 'urlHistory') {
       // urlHistory is an array of old page urls. they're not component refs and shouldn't be versioned
-      result = _.map(value, replaceVersion);
+      result = _.map(value, replace);
     } else {
       result = value;
     }
@@ -158,7 +158,7 @@ function replacePageReferenceVersions(data, version) {
  * @returns {Promise}
  */
 function getLatestData(uri) {
-  return db.get(references.replaceVersion(uri)).then(JSON.parse);
+  return db.get(replaceVersion(uri)).then(JSON.parse);
 }
 
 /**
@@ -178,7 +178,7 @@ function getRecursivePublishedPutOperations(locals) {
      */
     return components.get(rootComponentRef, locals)
       .then(data => composer.resolveComponentReferences(data, locals))
-      .then(data => components.getPutOperations(references.replaceVersion(rootComponentRef, published), data, locals));
+      .then(data => components.getPutOperations(replaceVersion(rootComponentRef, published), data, locals));
   };
 }
 
@@ -232,7 +232,7 @@ function addOpToMakePublic(ops, sitePrefix, publicUrl, pageUri) {
   ops.push({
     type: 'put',
     key: `${sitePrefix}/_uris/${buf.encode(references.urlToUri(publicUrl))}`,
-    value: references.replaceVersion(pageUri)
+    value: replaceVersion(pageUri)
   });
 }
 
@@ -245,7 +245,7 @@ function addOpToMakePublic(ops, sitePrefix, publicUrl, pageUri) {
  */
 function publish(uri, data, locals) {
   const startTime = process.hrtime(),
-    prefix = references.getPagePrefix(uri),
+    prefix = getPrefix(uri),
     site = getSite(prefix, locals),
     timeoutLimit = timeoutConstant * timeoutPublishCoefficient;
 
@@ -271,7 +271,7 @@ function publish(uri, data, locals) {
           addOpToMakePublic(ops, prefix, publicUrl, uri);
 
           // add page PUT operation last
-          return addOp(references.replaceVersion(uri, published), pageData, ops);
+          return addOp(replaceVersion(uri, published), pageData, ops);
         });
     }).then(applyBatch(site)).tap(function () {
       const ms = timer.getMillisecondsSince(startTime);
@@ -279,7 +279,7 @@ function publish(uri, data, locals) {
       if (ms > timeoutLimit * 0.5) {
         log('warn', `slow publish ${uri} ${ms}ms`);
       } else {
-        log('info', `published ${references.replaceVersion(uri)} ${ms}ms`);
+        log('info', `published ${replaceVersion(uri)} ${ms}ms`);
       }
     }).timeout(timeoutLimit, `Page publish exceeded ${timeoutLimit}ms: ${uri}`)
     .then(function (publishedData) {

--- a/lib/services/publish.js
+++ b/lib/services/publish.js
@@ -11,7 +11,7 @@ const _ = require('lodash'),
   db = require('./db'),
   buf = require('./buffer'),
   chain = require('chain-of-promises'),
-  references = require('./references');
+  { getPrefix } = require('clayutils');
 
 /**
  * grab any old urls from the published page (if it exist) and save them in the current page
@@ -83,7 +83,7 @@ function addRedirects(urlHistory, uri) {
       prevUri = `${prevUrl.hostname}${prevUrl.pathname}`,
       newUrl = parse(_.last(urlHistory)),
       newUri = `${newUrl.hostname}${newUrl.pathname}`,
-      prefix = references.getPagePrefix(uri);
+      prefix = getPrefix(uri);
 
     // update the previous uri to point to the latest uri
     return db.put(`${prefix}/_uris/${buf.encode(prevUri)}`, `${prefix}/_uris/${buf.encode(newUri)}`);

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const _ = require('lodash'),
-  urlParse = require('url');
+  urlParse = require('url'),
+  { replaceVersion } = require('clayutils');
 let propagatingVersions = ['published', 'latest'];
 
 /**
@@ -36,26 +37,6 @@ function listDeepObjects(obj, filter) {
   }
 
   return list;
-}
-
-/**
- * @param {string} uri
- * @param {string} [version]
- * @returns {string}
- */
-function replaceVersion(uri, version) {
-  if (!_.isString(uri)) {
-    throw new TypeError('Uri must be a string, not ' + typeof uri);
-  }
-
-  if (version) {
-    uri = uri.split('@')[0] + '@' + version;
-  } else {
-    // no version is still a kind of version
-    uri = uri.split('@')[0];
-  }
-
-  return uri;
 }
 
 /**
@@ -138,25 +119,6 @@ function urlToUri(url) {
   return parts.hostname + parts.path;
 }
 
-/**
- * Get the prefix of a page like 'some-domain.com/some-path/_pages/' with the page id.
- *
- * @param {string} uri
- * @returns {string}
- */
-function getPagePrefix(uri) {
-  return uri.substr(0, uri.indexOf('/_pages/'));
-}
-
-/**
- * Get the prefix like 'some-domain.com/some-path/_uris/some-uri' into 'some-domain.com/some-path'.
- *
- * @param {string} uri
- * @returns {string}
- */
-function getUriPrefix(uri) {
-  return uri.substr(0, uri.indexOf('/_uris/'));
-}
 
 /**
  * Remove the configuration properties of a page, leaving only page-level references
@@ -186,8 +148,6 @@ module.exports.isUrl = isUrl;
 module.exports.isUri = isUri;
 module.exports.uriToUrl = uriToUrl;
 module.exports.urlToUri = urlToUri;
-module.exports.getPagePrefix = getPagePrefix;
-module.exports.getUriPrefix = getUriPrefix;
 module.exports.omitPageConfiguration = omitPageConfiguration;
 module.exports.getPageReferences = getPageReferences;
 module.exports.listDeepObjects = listDeepObjects;

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash'),
   urlParse = require('url'),
-  { replaceVersion } = require('clayutils');
+  { replaceVersion, getPrefix } = require('clayutils');
 let propagatingVersions = ['published', 'latest'];
 
 /**
@@ -151,3 +151,7 @@ module.exports.urlToUri = urlToUri;
 module.exports.omitPageConfiguration = omitPageConfiguration;
 module.exports.getPageReferences = getPageReferences;
 module.exports.listDeepObjects = listDeepObjects;
+
+// TODO: Remove these on next major release
+module.exports.getPagePrefix = getPrefix;
+module.exports.getUriPrefix = getPrefix;

--- a/lib/services/references.test.js
+++ b/lib/services/references.test.js
@@ -17,26 +17,6 @@ describe(_.startCase(filename), function () {
     sandbox.restore();
   });
 
-  describe('replaceVersion', function () {
-    const fn = lib[this.title];
-
-    it('throws error when not given string', function () {
-      expect(function () { fn(); }).to.throw('Uri must be a string, not undefined');
-    });
-
-    it('replaces version with new version', function () {
-      expect(fn('a@b', 'c')).to.equal('a@c');
-    });
-
-    it('replaces version with no version', function () {
-      expect(fn('a@b')).to.equal('a');
-    });
-
-    it('replaces no version with version', function () {
-      expect(fn('a', 'c')).to.equal('a@c');
-    });
-  });
-
   describe('replaceAllVersions', function () {
     const fn = lib[this.title];
 

--- a/lib/services/schedule.js
+++ b/lib/services/schedule.js
@@ -7,7 +7,7 @@ var interval,
   });
 const _ = require('lodash'),
   bluebird = require('bluebird'),
-  clayutils = require('clayutils'),
+  { replaceVersion, isPage } = require('clayutils'),
   db = require('./db'),
   references = require('./references'),
   buf = require('./buffer'),
@@ -32,7 +32,7 @@ function setScheduleInterval(value) {
  */
 function publishExternally(url) {
   return bluebird.try(function () {
-    const published = references.replaceVersion(url, 'published');
+    const published = replaceVersion(url, 'published');
 
     return rest.putObject(published);
   });
@@ -96,14 +96,14 @@ function createScheduleObjectKey(uri, data) {
 function del(uri, user) {
   return db.get(uri).then(JSON.parse).then(function (data) {
     const targetUri = references.urlToUri(data[publishProperty]),
-      targetReference = references.replaceVersion(targetUri, scheduledVersion),
+      targetReference = replaceVersion(targetUri, scheduledVersion),
       ops = [
         { type: 'del', key: uri },
         { type: 'del', key: targetReference }
       ];
 
     return db.batch(ops).then(function () {
-      if (clayutils.isPage(targetUri)) {
+      if (isPage(targetUri)) {
         plugins.executeHook('unschedulePage', { uri: targetUri, data: data, user: user });
       }
     }).return(data);
@@ -120,7 +120,7 @@ function del(uri, user) {
 function post(uri, data, user) {
   const reference = createScheduleObjectKey(uri, data),
     targetUri = references.urlToUri(data[publishProperty]),
-    targetReference = references.replaceVersion(targetUri, scheduledVersion),
+    targetReference = replaceVersion(targetUri, scheduledVersion),
     referencedData = _.assign({_ref: reference}, data),
     ops = [
       { type: 'put', key: reference, value: JSON.stringify(data) },
@@ -129,7 +129,7 @@ function post(uri, data, user) {
 
   return db.batch(ops).then(function () {
     log('info', `scheduled ${targetUri} (${data.at})`);
-    if (clayutils.isPage(targetUri)) {
+    if (isPage(targetUri)) {
       plugins.executeHook('schedulePage', { uri: targetUri, data: data, user: user });
     }
   }).return(referencedData);

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -105,15 +105,30 @@ function getSite(host, path) {
 }
 
 /**
- * Get the site a prefix belongs to
+ * Get the site a URI belongs to
+ *
  * @param {string} prefix
  * @returns {object}
  */
 function getSiteFromPrefix(prefix) {
-  let [host, ...splitPath] = prefix.split('/'),
-    path = splitPath.join('/');
+  var split = prefix.split('/'), // Split the url/uri by `/`
+    host = split.shift(),        // The first value should be the host ('http://' is not included)
+    optPath = split.shift(),  // The next value is the first part of the site's path OR the whole part
+    path = optPath ? `/${optPath}` : '',
+    length = split.length + 1,   // We always need at least one pass through the for loop
+    site;                        // Initialize the return value to `undefined`
 
-  return getSite(host, path ? '/' + path : path);
+  for (let i = 0; i < length; i++) {
+    site = getSite(host, path); // Try to get the site based on the host and path
+
+    if (site) { // If a site was found, break out of the loop
+      break;
+    } else {
+      path += `/${split.shift()}`; // Grab the next value and append it to the `path` value
+    }
+  }
+
+  return site; // Return the site
 }
 
 module.exports.sites = _.memoize(getSites);

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -105,30 +105,15 @@ function getSite(host, path) {
 }
 
 /**
- * Get the site a URI belongs to
- *
+ * Get the site a prefix belongs to
  * @param {string} prefix
  * @returns {object}
  */
 function getSiteFromPrefix(prefix) {
-  var split = prefix.split('/'), // Split the url/uri by `/`
-    host = split.shift(),        // The first value should be the host ('http://' is not included)
-    optPath = split.shift(),  // The next value is the first part of the site's path OR the whole part
-    path = optPath ? `/${optPath}` : '',
-    length = split.length + 1,   // We always need at least one pass through the for loop
-    site;                        // Initialize the return value to `undefined`
+  let [host, ...splitPath] = prefix.split('/'),
+    path = splitPath.join('/');
 
-  for (let i = 0; i < length; i++) {
-    site = getSite(host, path); // Try to get the site based on the host and path
-
-    if (site) { // If a site was found, break out of the loop
-      break;
-    } else {
-      path += `/${split.shift()}`; // Grab the next value and append it to the `path` value
-    }
-  }
-
-  return site; // Return the site
+  return getSite(host, path ? '/' + path : path);
 }
 
 module.exports.sites = _.memoize(getSites);

--- a/lib/services/uris.js
+++ b/lib/services/uris.js
@@ -4,6 +4,7 @@ const _ = require('lodash'),
   buf = require('./buffer'),
   db = require('./db'),
   references = require('./references'),
+  { getPrefix } = require('clayutils'),
   notifications = require('./notifications'),
   siteService = require('./sites'),
   plugins = require('../plugins');
@@ -50,7 +51,7 @@ function put(uri, body) {
 function del(uri, user) {
   return get(uri).then(function (oldData) {
     return db.del(uri).then(function () {
-      const prefix = references.getUriPrefix(uri),
+      const prefix = getPrefix(uri),
         site = siteService.getSiteFromPrefix(prefix),
         pageUrl = buf.decode(uri.split('/').pop());
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,7 +238,7 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
     },
     "body-parser": {
       "version": "1.18.2",
@@ -418,7 +418,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "clay-log": {
@@ -431,9 +431,9 @@
       }
     },
     "clayutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/clayutils/-/clayutils-2.0.3.tgz",
-      "integrity": "sha512-6oEhoGLV3UHwdXbybf/+R5wIffn36YSdHvKEvouZmm37VMaLEjI6aOWND/nTfsF3m5qAxUxTmJl1zrYnWoBGAg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clayutils/-/clayutils-2.1.0.tgz",
+      "integrity": "sha512-UCzssPzbsSEoFGCj9JGrXDqQ1FD5a0LzZ4FHWda2zQ+d2IzcWm7Matf/3aPSZsUKd07IIARvJ405aupY97ZQwQ==",
       "requires": {
         "glob": "7.1.2",
         "lodash": "4.17.5",
@@ -627,7 +627,7 @@
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -721,7 +721,7 @@
     "deferred-leveldown": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
+      "integrity": "sha1-Os0uC3XRZpkkvApLZChRExFz4es=",
       "requires": {
         "abstract-leveldown": "2.6.3"
       }
@@ -1031,7 +1031,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
     },
     "esquery": {
       "version": "1.0.0",
@@ -1335,7 +1335,7 @@
     "gitbook-cli": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/gitbook-cli/-/gitbook-cli-2.3.2.tgz",
-      "integrity": "sha512-eyGtkY7jKHhmgpfuvgAP5fZcUob/FBz4Ld0aLRdEmiTrS1RklimN9epzPp75dd4MWpGhYvSbiwxnpyLiv1wh6A==",
+      "integrity": "sha1-Xok1guH3Q/b6kgw8PrNrYupKMaA=",
       "dev": true,
       "requires": {
         "bash-color": "0.0.4",
@@ -1410,7 +1410,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -2032,12 +2032,12 @@
     "level-codec": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
+      "integrity": "sha1-NB8i+QfODxZ2PyS93WgeOVoPuKc="
     },
     "level-errors": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
+      "integrity": "sha1-g9v7EvC4olFr3JoxxIdgOOInuFk=",
       "requires": {
         "errno": "0.1.6"
       }
@@ -2079,7 +2079,7 @@
     "levelup": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
+      "integrity": "sha1-LbyuhFsrsra+qE3zNMR1Uzu9gqs=",
       "requires": {
         "deferred-leveldown": "1.2.2",
         "level-codec": "7.0.1",
@@ -2230,7 +2230,7 @@
         "abstract-leveldown": {
           "version": "2.7.2",
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "integrity": "sha1-h6RNfr68NB1ZZlIEg0yLfgkyzJM=",
           "requires": {
             "xtend": "4.0.1"
           }
@@ -2274,7 +2274,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.11"
       }
@@ -2302,7 +2302,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -2499,7 +2499,7 @@
     "npm": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.1.0.tgz",
-      "integrity": "sha512-pt5ClxEmY/dLpb60SmGQQBKi3nB6Ljx1FXmpoCUdAULlGqGVn2uCyXxPCWFbcuHGthT7qGiaGa1wOfs/UjGYMw==",
+      "integrity": "sha1-z4IB4EQBjpyJUyBByQCUVBmCssA=",
       "dev": true,
       "requires": {
         "JSONStream": "1.3.1",
@@ -7577,7 +7577,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -7610,7 +7610,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "safe-json-stringify": {
       "version": "1.0.4",
@@ -7627,7 +7627,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
     },
     "send": {
       "version": "0.16.1",
@@ -7779,7 +7779,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -8056,7 +8056,7 @@
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "integrity": "sha1-Kz1cckDo/C5Y+Komnl7knAhXvTo=",
       "requires": {
         "random-bytes": "1.0.0"
       }
@@ -8143,7 +8143,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "body-parser": "^1.12",
     "chain-of-promises": "^1.0.0",
     "clay-log": "^1.2.0",
-    "clayutils": "^2.0.3",
+    "clayutils": "^2.1.0",
     "cuid": "^1.2.5",
     "eventify": "^2.0.0",
     "express": "^4.15.3",


### PR DESCRIPTION
`clayutils` now provides `replaceVersion`, `getPrefix`. This PR updates amphora to remove equivalent functions from the `references` module and edits all dependent modules to use the clayutils functions instead. It also simplifies the `getSiteFromPrefix` function.