### PR TITLE
logging message rather than throwing

### DIFF
--- a/lib/services/composer.js
+++ b/lib/services/composer.js
@@ -6,6 +6,7 @@ const _ = require('lodash'),
   references = require('./references'),
   mapLayoutToPageData = require('../utils/layout-to-page-data'),
   referenceProperty = '_ref';
+var log = require('./logger').setup({ file: __filename });
 
 /**
  * Compose a component, recursively filling in all component references with
@@ -26,11 +27,12 @@ function resolveComponentReferences(data, locals, filter = referenceProperty) {
         return resolveComponentReferences(obj, locals, filter).finally(function () {
           _.assign(referenceObject, _.omit(obj, referenceProperty));
         }).catch(function (error) {
-          // add additional information to the error message
-          const wrappedError = new Error(error.message + ' within ' + referenceObject[referenceProperty]);
+          log('error', `${error.message} within ${referenceObject[referenceProperty]}`, {
+            name: error.name,
+            stack: error.stack
+          });
 
-          wrappedError.name = error.name;
-          throw wrappedError;
+          return bluebird.reject(error);
         });
       });
   }).return(data);
@@ -55,3 +57,6 @@ function composePage(pageData, locals) {
 
 module.exports.resolveComponentReferences = resolveComponentReferences;
 module.exports.composePage = composePage;
+
+// For testing
+module.exports.setLog = (fakeLogger) => log = fakeLogger;

--- a/lib/services/composer.test.js
+++ b/lib/services/composer.test.js
@@ -9,11 +9,14 @@ const _ = require('lodash'),
   sinon = require('sinon');
 
 describe(_.startCase(filename), function () {
-  let sandbox;
+  let sandbox, logSpy;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    logSpy = sandbox.spy();
+
     sandbox.stub(components);
+    lib.setLog(logSpy);
   });
 
   afterEach(function () {
@@ -104,9 +107,9 @@ describe(_.startCase(filename), function () {
       components.get.withArgs('/c/m').returns(bluebird.reject(myError));
 
       // use done() rather than returning the promise, so we can catch and test errors
-      fn(data).then(done).catch(function (error) {
-        expect(error.message).to.equal('hello! within /c/e');
-        expect(error.message).to.match(/hello! within \/c\/e/);
+      fn(data).then(done).catch((error) => {
+        sinon.assert.calledOnce(logSpy);
+        expect(error.message).to.equal('hello!');
         done();
       });
     });


### PR DESCRIPTION
Tangentially relating to part of #403.

Error in composer for a missing schema isn't being logged through the logging service. 