### PR TITLE
Component Error Page

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -13,6 +13,7 @@ const _ = require('lodash'),
   clayUtils = require('clayutils'),
   db = require('./services/db'),
   composer = require('./services/composer'),
+  responses = require('./responses'),
   mapLayoutToPageData = require('./utils/layout-to-page-data');
 
 /**
@@ -116,7 +117,8 @@ function renderPage(uri, req, res, hrStart) {
   return getDBObject(uri)
     .then(formDataFromLayout(locals, uri))
     .tap(logTime(hrStart, uri))
-    .then(({ data, options }) => renderer.render(data, options, res));;
+    .then(({ data, options }) => renderer.render(data, options, res))
+    .catch(responses.handleError(res));
 }
 
 /**

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -13,6 +13,7 @@ const _ = require('lodash'),
   bluebird = require('bluebird'),
   filter = require('through2-filter'),
   map = require('through2-map'),
+  { getComponentName, getComponentInstance } = require('clayutils'),
   referencedProperty = '_ref';
 
 /**
@@ -326,13 +327,36 @@ function clientError(err, res) {
 }
 
 /**
+ * Handler for component triggering an error. Both logs
+ * the component message and sends the response to the client.
+ *
+ * @param  {Error} err
+ * @param  {Object} res
+ */
+function componentError(err, res) {
+  const { cmptUri, message, code } = err,
+    cmpt = getComponentName(cmptUri);
+
+  log('error', `${cmpt}: ${message} (${code})`, {
+    code,
+    action: 'componentError',
+    cmpt,
+    instance: getComponentInstance(cmptUri)
+  });
+
+  sendDefaultResponseForCode(code, message, res);
+}
+
+/**
  * Handle errors in the standard/generic way
  * @param {object} res
  * @returns {function}
  */
 function handleError(res) {
   return function (err) {
-    if (err.name === 'NotFoundError' ||
+    if (err.name === 'ComponentError') {
+      componentError(err, res);
+    } else if (err.name === 'NotFoundError' ||
       err.message.indexOf('ENOENT') !== -1 ||
       err.message.indexOf('not found') !== -1) {
       notFound(err, res);

--- a/lib/responses.test.js
+++ b/lib/responses.test.js
@@ -83,6 +83,23 @@ describe(_.startCase(filename), function () {
   describe('handleError', function () {
     const fn = lib[this.title];
 
+    it('sends the error a component specifies', function (done) {
+      const res = createMockRes(),
+        err = new Error('not found');
+
+      err.name = 'ComponentError';
+      err.code = 404;
+      err.cmptUri = 'example.com/_components/foo/instances/bar';
+
+      expectStatus(res, 404);
+      expectResult(res, 'sendStatus: whatever', function () {
+        sinon.assert.calledOnce(fakeLog);
+        done();
+      });
+
+      fn(res)(err);
+    });
+
     it('sends 404 if "not found"', function (done) {
       const res = createMockRes();
 

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -58,14 +58,12 @@ function get(uri, locals) {
     const startTime = process.hrtime(),
       timeoutLimit = timeoutConstant * timeoutGetCoefficient;
 
-    promise = bluebird.try(function () {
+    promise = bluebird.try(() => {
       return db.get(uri)
         .then(JSON.parse)
         .then(upgrade.init(uri, locals)) // Run an upgrade!
-        .then(function (data) {
-          return componentModule.render(uri, data, locals);
-        });
-    }).tap(function (result) {
+        .then(data => componentModule.render(uri, data, locals, non200Response(uri)));
+    }).tap(result => {
       const ms = timer.getMillisecondsSince(startTime);
 
       if (!_.isObject(result)) {
@@ -80,9 +78,10 @@ function get(uri, locals) {
     promise = db.get(uri).then(JSON.parse).then(upgrade.init(uri, locals)); // Run an upgrade!
   }
 
+  //  Renderer specific model
   if (renderModel) {
     promise = promise.then(function (data) {
-      return renderModel(uri, data, locals);
+      return renderModel(uri, data, locals, non200Response(uri));
     });
   }
 
@@ -93,6 +92,25 @@ function get(uri, locals) {
 
     return data;
   });
+}
+
+/**
+ * Allow components to control a non-200 response
+ * from their model.js.
+ *
+ * @param  {String} uri [description]
+ * @return {Function}     [description]
+ */
+function non200Response(uri) {
+  return (code = 404, msg = 'Not Found') => {
+    const err = new Error(msg);
+
+    err.name = 'ComponentError';
+    err.code = code;
+    err.cmptUri = uri;
+
+    return bluebird.reject(err);
+  };
 }
 
 /**

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -356,6 +356,21 @@ describe(_.startCase(filename), function () {
         sinon.assert.calledWith(renderSpy, ref, data, locals);
       });
     });
+
+    it('allows components to reject for a non-200 response', function () {
+      const ref = 'domain.com/path/_components/whatever',
+        locals = { componenthooks: true },
+        data = {a: 'b'};
+
+      db.get.returns(Promise.resolve(JSON.stringify(data)));
+      files.getComponentModule.returns({render: (r, d, l, f) => f(404, 'testing')});
+
+      return fn(ref, locals)
+        .catch(e => {
+          expect(e.code).to.equal(404);
+          expect(e.message).to.equal('testing');
+        });
+    });
   });
 
   describe('list', function () {

--- a/lib/services/composer.js
+++ b/lib/services/composer.js
@@ -35,7 +35,7 @@ function resolveComponentReferences(data, locals, filter = referenceProperty) {
           return bluebird.reject(error);
         });
       });
-  }).return(data);
+  }).then(() => data);
 }
 
 /**


### PR DESCRIPTION
https://github.com/clay/amphora/issues/466

Allows components with a model.js to cause a request for a page to error with the response code of the component's choice. The error, code and everything will be both logged and sent to the client.

 Use cases:

- You have a newsfeed who only has 100 items and want to 404 when a user requests a page that starts above 100.
- You have a ✨ dynamic route ✨ and not you want to 404 on bad routes
- You have a hard dependency on an external service and it's down/slow so you want to 500

## Caveats
- Only sends the message of the last component to error because all components are resolved in a batch
- All components are still resolved before the error is sent because the current composer is not streamed/doesn't have a quick escape built into it. 

Both caveats are easy to take care of since their origin is the same.



