### PR TITLE
Component Specify Error Response Code

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -13,6 +13,7 @@ const _ = require('lodash'),
   clayUtils = require('clayutils'),
   db = require('./services/db'),
   composer = require('./services/composer'),
+  responses = require('./responses'),
   mapLayoutToPageData = require('./utils/layout-to-page-data');
 
 /**
@@ -116,7 +117,8 @@ function renderPage(uri, req, res, hrStart) {
   return getDBObject(uri)
     .then(formDataFromLayout(locals, uri))
     .tap(logTime(hrStart, uri))
-    .then(({ data, options }) => renderer.render(data, options, res));;
+    .then(({ data, options }) => renderer.render(data, options, res))
+    .catch(responses.handleError(res));
 }
 
 /**

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -332,7 +332,11 @@ function clientError(err, res) {
  */
 function handleError(res) {
   return function (err) {
-    if (err.name === 'NotFoundError' ||
+    if (err.status && err.name !== 'NotFoundError') {
+      // If we're in this block, the error has a defined `status` property and
+      // the error should be directed out immediately
+      sendDefaultResponseForCode(err.status, err.message, res);
+    } else if (err.name === 'NotFoundError' ||
       err.message.indexOf('ENOENT') !== -1 ||
       err.message.indexOf('not found') !== -1) {
       notFound(err, res);

--- a/lib/responses.test.js
+++ b/lib/responses.test.js
@@ -104,6 +104,16 @@ describe(_.startCase(filename), function () {
       });
       fn(res)(new Error('something'));
     });
+
+    it('sends the error code defined in the `status` property', function (done) {
+      const res = createMockRes(),
+        myError = new Error('something');
+
+      myError.status = 403;
+      expectStatus(res, 403);
+      expectResult(res, 'sendStatus: whatever', done);
+      fn(res)(myError);
+    });
   });
 
   describe('unauthorized', function () {

--- a/lib/services/composer.js
+++ b/lib/services/composer.js
@@ -27,15 +27,21 @@ function resolveComponentReferences(data, locals, filter = referenceProperty) {
         return resolveComponentReferences(obj, locals, filter).finally(function () {
           _.assign(referenceObject, _.omit(obj, referenceProperty));
         }).catch(function (error) {
-          log('error', `${error.message} within ${referenceObject[referenceProperty]}`, {
-            name: error.name,
-            stack: error.stack
-          });
+          const logObj = {
+            stack: error.stack,
+            cmpt: referenceObject[referenceProperty]
+          };
+
+          if (error.status) {
+            logObj.status = error.status;
+          }
+
+          log('error', `${error.message}`, logObj);
 
           return bluebird.reject(error);
         });
       });
-  }).return(data);
+  }).then(() => data);
 }
 
 /**

--- a/lib/services/composer.test.js
+++ b/lib/services/composer.test.js
@@ -113,6 +113,27 @@ describe(_.startCase(filename), function () {
         done();
       });
     });
+
+    it('adds the status to the error message if it one is defined', function (done) {
+      const data = {
+          a: {_ref: '/c/b'},
+          c: {d: {_ref: '/c/e'}}
+        },
+        myError = new Error('hello!');
+
+      myError.status = 404;
+      components.get.withArgs('/c/b').returns(bluebird.resolve({g: 'h'}));
+      components.get.withArgs('/c/e').returns(bluebird.resolve({i: 'j', k: {_ref: '/c/m'}}));
+      components.get.withArgs('/c/m').returns(bluebird.reject(myError));
+
+      // use done() rather than returning the promise, so we can catch and test errors
+      fn(data).then(done).catch((error) => {
+        sinon.assert.calledOnce(logSpy);
+        expect(error.message).to.equal('hello!');
+        sinon.assert.calledWith(logSpy, 'error', 'hello!', { status: myError.status, cmpt: '/c/e', stack: myError.stack });
+        done();
+      });
+    });
   });
 
   describe('composePage', function () {


### PR DESCRIPTION
Allows components to specify a response code when throwing an error. If no `status` is defined the component will still `500`.

- Status will be logged when specified
- component instance will be logged in its own property to make it more searchable


```javascript
module.exports.render = (uri, data, locals) => {
  var foo = new Error('no results for this page!');
  foo.status = 404;
  throw foo;
};
```