### PR TITLE
call publishLayout hook when publishing layouts

### DIFF
--- a/lib/plugins/readme.md
+++ b/lib/plugins/readme.md
@@ -80,3 +80,7 @@ Note that `publish` and `unpublish` are used by certain plugins, but they will b
   - hook triggered on page unscheduling
   - _note:_ when `unschedulePage` is triggered, `save` is also triggered
   - given one param with uri, data, and user: `{ uri: scheduledItemUri, data: { at: timestamp, publish: pageUri }, user: req.user }`
+
+### Layout-specific Methods
+
+Layouts only have one hook, called `publishLayout`. It is called with the same arguments as `publishPage`, namely `{ uri, data, user }`.

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -19,6 +19,7 @@ const _ = require('lodash'),
   bluebird = require('bluebird'),
   upgrade = require('./upgrade'),
   { getComponentName, replaceVersion } = require('clayutils'),
+  plugins = require('../plugins'),
   referenceProperty = '_ref',
   timeoutGetCoefficient = 2,
   timeoutPutCoefficient = 5;
@@ -343,6 +344,17 @@ function filterBaseInstanceReferences(obj) {
 }
 
 /**
+ * determine if a component is a layout, by checking its schema
+ * @param  {string}  uri
+ * @return {Promise}
+ */
+function isLayout(uri) {
+  return getSchema(uri).then((schema) => {
+    return _.has(schema, '_layout');
+  }).catch(() => false);
+}
+
+/**
  *
  * @param {string} uri
  * @param {object} data
@@ -356,7 +368,13 @@ function publish(uri, data, locals) {
 
   return get(replaceVersion(uri), locals)
     .then(latestData => composer.resolveComponentReferences(latestData, locals, filterBaseInstanceReferences))
-    .then(versionedData => cascadingPut(uri, versionedData, locals));
+    .then(versionedData => cascadingPut(uri, versionedData, locals))
+    .then(publishedData => isLayout(uri).then((definitelyALayout) => {
+      if (definitelyALayout) {
+        plugins.executeHook('publishLayout', { uri: uri, data: publishedData, user: locals && locals.user });
+      }
+      return publishedData;
+    }));
 }
 
 /**

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -363,7 +363,13 @@ function isLayout(uri) {
  */
 function publish(uri, data, locals) {
   if (data && _.size(data) > 0) {
-    return cascadingPut(uri, data, locals);
+    return cascadingPut(uri, data, locals)
+      .then(publishedData => isLayout(uri).then((definitelyALayout) => {
+        if (definitelyALayout) {
+          plugins.executeHook('publishLayout', { uri: uri, data: publishedData, user: locals && locals.user });
+        }
+        return publishedData;
+      }));
   }
 
   return get(replaceVersion(uri), locals)

--- a/lib/services/components.js
+++ b/lib/services/components.js
@@ -350,7 +350,7 @@ function filterBaseInstanceReferences(obj) {
  */
 function isLayout(uri) {
   return getSchema(uri).then((schema) => {
-    return _.has(schema, '_layout');
+    return _.get(schema, '_layout', false);
   }).catch(() => false);
 }
 

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -11,6 +11,7 @@ const _ = require('lodash'),
   bluebird = require('bluebird'),
   upgrade = require('./upgrade'),
   schema = require('../schema'),
+  plugins = require('../plugins'),
   expect = require('chai').expect;
 
 describe(_.startCase(filename), function () {
@@ -29,6 +30,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(timer);
     sandbox.stub(upgrade);
     sandbox.stub(schema);
+    sandbox.stub(plugins);
 
     lib.getSchema.cache = new _.memoize.Cache();
 
@@ -254,16 +256,16 @@ describe(_.startCase(filename), function () {
       });
     });
 
-    it('executes publishLayout hook if publishing a layout', function () {
+    it('executes plugin hook if publishing a layout', function () {
       const uri = 'some uri',
         data = {a: 'b'};
 
       db.batch.returns(bluebird.resolve());
       schema.getSchema.returns(Promise.resolve({ _layout: true }));
 
-      return fn(uri, data).then(function (result) {
-        expect(result).to.deep.equal(data);
-        sinon.assert.calledWith(db.batch, [{ type: 'put', key: 'some uri', value: JSON.stringify(data) }]);
+      return fn(uri, data).then(function () {
+        expect(plugins.executeHook.called).to.equal(true);
+        expect(plugins.executeHook.getCall(0).args[0]).to.equal('publishLayout');
       });
     });
   });

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -10,6 +10,7 @@ const _ = require('lodash'),
   timer = require('../timer'),
   bluebird = require('bluebird'),
   upgrade = require('./upgrade'),
+  schema = require('../schema'),
   expect = require('chai').expect;
 
 describe(_.startCase(filename), function () {
@@ -27,6 +28,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(files);
     sandbox.stub(timer);
     sandbox.stub(upgrade);
+    sandbox.stub(schema);
 
     lib.getSchema.cache = new _.memoize.Cache();
 
@@ -205,6 +207,7 @@ describe(_.startCase(filename), function () {
         data = {a: 'b'};
 
       db.batch.returns(bluebird.resolve());
+      schema.getSchema.returns(Promise.reject());
 
       return fn(uri, data).then(function (result) {
         expect(result).to.deep.equal(data);
@@ -221,6 +224,7 @@ describe(_.startCase(filename), function () {
       db.batch.returns(bluebird.resolve());
       db.get.withArgs(uri).returns(bluebird.resolve(JSON.stringify(data)));
       db.get.withArgs(deepUri).returns(bluebird.resolve(JSON.stringify(deepData)));
+      schema.getSchema.returns(Promise.resolve({}));
 
       return fn(uri).then(function (result) {
         expect(result).to.deep.equal(data);
@@ -240,12 +244,26 @@ describe(_.startCase(filename), function () {
       db.batch.returns(bluebird.resolve());
       db.get.withArgs(uri).returns(bluebird.resolve(JSON.stringify(data)));
       db.get.withArgs(deepUri).returns(bluebird.resolve(JSON.stringify(deepData)));
+      schema.getSchema.returns(Promise.resolve({ _layout: false }));
 
       return fn(uri).then(function (result) {
         expect(result).to.deep.equal(data);
         sinon.assert.calledWith(db.batch, [
           { key: 'some uri', type: 'put', value: '{"a":"b","c":{"_ref":"d/_components/e"}}'}
         ]);
+      });
+    });
+
+    it('executes publishLayout hook if publishing a layout', function () {
+      const uri = 'some uri',
+        data = {a: 'b'};
+
+      db.batch.returns(bluebird.resolve());
+      schema.getSchema.returns(Promise.resolve({ _layout: true }));
+
+      return fn(uri, data).then(function (result) {
+        expect(result).to.deep.equal(data);
+        sinon.assert.calledWith(db.batch, [{ type: 'put', key: 'some uri', value: JSON.stringify(data) }]);
       });
     });
   });

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -268,6 +268,23 @@ describe(_.startCase(filename), function () {
         expect(plugins.executeHook.getCall(0).args[0]).to.equal('publishLayout');
       });
     });
+
+    it('executes plugin hook if publishing a composed layout', function () {
+      const uri = 'some uri',
+        deepUri = 'd/_components/e/instances/f',
+        data = {a: 'b', c: {_ref: deepUri}},
+        deepData = {g: 'h'};
+
+      db.batch.returns(bluebird.resolve());
+      db.get.withArgs(uri).returns(bluebird.resolve(JSON.stringify(data)));
+      db.get.withArgs(deepUri).returns(bluebird.resolve(JSON.stringify(deepData)));
+      schema.getSchema.returns(Promise.resolve({ _layout: true }));
+
+      return fn(uri, data).then(function () {
+        expect(plugins.executeHook.called).to.equal(true);
+        expect(plugins.executeHook.getCall(0).args[0]).to.equal('publishLayout');
+      });
+    });
   });
 
   describe('get', function () {

--- a/lib/services/components.test.js
+++ b/lib/services/components.test.js
@@ -263,13 +263,13 @@ describe(_.startCase(filename), function () {
       db.batch.returns(bluebird.resolve());
       schema.getSchema.returns(Promise.resolve({ _layout: true }));
 
-      return fn(uri, data).then(function () {
+      return fn(uri, data, { user: { name: 'someone' }}).then(function () {
         expect(plugins.executeHook.called).to.equal(true);
         expect(plugins.executeHook.getCall(0).args[0]).to.equal('publishLayout');
       });
     });
 
-    it('executes plugin hook if publishing a composed layout', function () {
+    it('executes plugin hook if publishing a layout without data', function () {
       const uri = 'some uri',
         deepUri = 'd/_components/e/instances/f',
         data = {a: 'b', c: {_ref: deepUri}},
@@ -280,7 +280,7 @@ describe(_.startCase(filename), function () {
       db.get.withArgs(deepUri).returns(bluebird.resolve(JSON.stringify(deepData)));
       schema.getSchema.returns(Promise.resolve({ _layout: true }));
 
-      return fn(uri, data).then(function () {
+      return fn(uri, null, { user: { name: 'someone' }}).then(function () {
         expect(plugins.executeHook.called).to.equal(true);
         expect(plugins.executeHook.getCall(0).args[0]).to.equal('publishLayout');
       });

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -15,6 +15,8 @@ const _ = require('lodash'),
   siteService = require('./sites'),
   timer = require('../timer'),
   uid = require('../uid'),
+  schema = require('../schema'),
+  files = require('../files'),
   { getComponentName, replaceVersion, getPrefix } = require('clayutils'),
   publishService = require('./publish'),
   plugins = require('../plugins'),
@@ -323,6 +325,18 @@ function create(uri, data, locals) {
 }
 
 /**
+ * determine if a referenced layout is actually a layout, by checking its schema
+ * @param  {string}  uri
+ * @return {Promise}
+ */
+function isLayout(uri) {
+  return bluebird.try(() => schema.getSchema(files.getComponentPath(getComponentName(uri))))
+    .then((schema) => {
+      return _.get(schema, '_layout', false);
+    }).catch(() => false);
+}
+
+/**
  * handle page PUTs (that aren't to @published)
  * checks to see if a page exists (to trigger `createPage` plugin hook),
  * then passes the data to the db
@@ -332,9 +346,18 @@ function create(uri, data, locals) {
  * @returns {Promise}
  */
 function putLatest(uri, data, locals) {
-  return getLatestData(uri)
-    .then(() => db.put(uri, JSON.stringify(data)).return(data)) // data already exists
-    .catch(() => db.put(uri, JSON.stringify(data)).then(() => plugins.executeHook('createPage', { uri, data, user: locals && locals.user })).return(data));
+  // check the page layout for the '_layout' boolean
+  return isLayout(data.layout).then((layoutIsLayout) => {
+    if (!layoutIsLayout) {
+      // todo: in the next major version, throw an error to prevent saving pages that reference incorrectly configured layouts
+      log('warn', `layout must specify '_layout: true' in its schema: ${data.layout}`);
+    }
+
+    // continue saving the page normally
+    return getLatestData(uri)
+      .then(() => db.put(uri, JSON.stringify(data)).return(data)) // data already exists
+      .catch(() => db.put(uri, JSON.stringify(data)).then(() => plugins.executeHook('createPage', { uri, data, user: locals && locals.user })).return(data));
+  });
 }
 
 module.exports.create = create;

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -11,7 +11,8 @@ const _ = require('lodash'),
   sinon = require('sinon'),
   siteService = require('./sites'),
   timer = require('../timer'),
-  plugins = require('../plugins');
+  plugins = require('../plugins'),
+  schema = require('../schema');
 
 describe(_.startCase(filename), function () {
   const timeoutConstant = 100;
@@ -28,6 +29,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(notifications, 'notify');
     sandbox.stub(timer);
     sandbox.stub(plugins);
+    sandbox.stub(schema);
 
     savedTimeoutConstant = lib.getTimeoutConstant();
     lib.setTimeoutConstant(timeoutConstant);
@@ -316,6 +318,7 @@ describe(_.startCase(filename), function () {
     it('passes through if page already exists', function () {
       db.get.returns(bluebird.resolve('{}'));
       db.put.returns(bluebird.resolve());
+      schema.getSchema.returns(Promise.resolve({ _layout: true }));
 
       return fn('domain.com/path/pages', {layout: 'domain.com/path/components/thing'}).then(function () {
         expect(plugins.executeHook.called).to.equal(false);
@@ -325,10 +328,41 @@ describe(_.startCase(filename), function () {
     it('calls create hook if page does not exist', function () {
       db.get.returns(bluebird.reject());
       db.put.returns(bluebird.resolve());
+      schema.getSchema.returns(Promise.resolve({ _layout: true }));
 
       return fn('domain.com/path/pages', {layout: 'domain.com/path/components/thing'}).then(function () {
         expect(plugins.executeHook.called).to.equal(true);
         expect(plugins.executeHook.getCall(0).args[0]).to.equal('createPage');
+      });
+    });
+
+    it('warns if referenced layout is not a real layout (false)', () => {
+      db.get.returns(bluebird.resolve('{}'));
+      db.put.returns(bluebird.resolve());
+      schema.getSchema.returns(Promise.resolve({ _layout: false }));
+
+      return fn('domain.com/path/pages', {layout: 'domain.com/path/components/thing'}).then(function () {
+        sinon.assert.calledWith(fakeLog, 'warn', sinon.match('layout must specify \'_layout: true\' in its schema: domain.com/path/components/thing'));
+      });
+    });
+
+    it('warns if referenced layout is not a real layout (undefined)', () => {
+      db.get.returns(bluebird.resolve('{}'));
+      db.put.returns(bluebird.resolve());
+      schema.getSchema.returns(Promise.resolve({}));
+
+      return fn('domain.com/path/pages', {layout: 'domain.com/path/components/thing'}).then(function () {
+        sinon.assert.calledWith(fakeLog, 'warn', sinon.match('layout must specify \'_layout: true\' in its schema: domain.com/path/components/thing'));
+      });
+    });
+
+    it('warns if referenced layout is not a real layout (reject)', () => {
+      db.get.returns(bluebird.resolve('{}'));
+      db.put.returns(bluebird.resolve());
+      schema.getSchema.returns(Promise.reject());
+
+      return fn('domain.com/path/pages', {layout: 'domain.com/path/components/thing'}).then(function () {
+        sinon.assert.calledWith(fakeLog, 'warn', sinon.match('layout must specify \'_layout: true\' in its schema: domain.com/path/components/thing'));
       });
     });
   });


### PR DESCRIPTION
* this implements the amphora portion of https://github.com/clay/clay-kiln/issues/1105
* amphora will look at component schemas (saved in memory) to see if they have a root-level `_layout` boolean. If so, it will execute the `publishLayout` hook
* warn when saving pages that reference layouts that _don't_ have the `_layout` property (we'll make this an error in the next major version)