### PR TITLE
publishing dynamic page

### DIFF
--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -257,9 +257,10 @@ function publish(uri, data, locals) {
     .then(function (pageData) {
       const published = 'published',
         publicUrl = pageData.customUrl || pageData.url,
+        dynamicPage = pageData._dynamic,
         componentList = references.getPageReferences(pageData);
 
-      if (!references.isUrl(publicUrl)) {
+      if (!references.isUrl(publicUrl) && !dynamicPage) {
         throw new Error('Client: Page must have valid url to publish.');
       }
 
@@ -269,8 +270,10 @@ function publish(uri, data, locals) {
           // convert the data to all @published
           pageData = replacePageReferenceVersions(pageData, published);
 
-          // make public
-          addOpToMakePublic(ops, prefix, publicUrl, uri);
+          // Make public unless we're dealing with a `_dynamic` page
+          if (!dynamicPage) {
+            addOpToMakePublic(ops, prefix, publicUrl, uri);
+          }
 
           // add page PUT operation last
           return addOp(replaceVersion(uri, published), pageData, ops);

--- a/lib/services/pages.test.js
+++ b/lib/services/pages.test.js
@@ -155,6 +155,26 @@ describe(_.startCase(filename), function () {
         });
     });
 
+    it('publishes dynamic pages', function () {
+      components.get.returns(bluebird.resolve({}));
+      db.get.returns(Promise.reject());
+      db.batch.returns(bluebird.resolve());
+      notifications.notify.returns(bluebird.resolve());
+
+      return fn('domain.com/path/_pages/thing@published', {layout: 'domain.com/path/_components/thing', _dynamic: true}, locals)
+        .then(function () {
+          const ops = db.batch.args[0][0],
+            secondLastOp = ops[ops.length - 2];
+
+
+          expect(secondLastOp).to.not.deep.equal({
+            type: 'put',
+            key: 'domain.com/path/_uris/c29tZS1kb21haW4uY29tLw==',
+            value: 'domain.com/path/_pages/thing'
+          });
+        });
+    });
+
     it('warns if publish is slow', function () {
       components.get.returns(bluebird.resolve({}));
       db.get.returns(Promise.reject());

--- a/lib/services/publish.js
+++ b/lib/services/publish.js
@@ -109,6 +109,22 @@ function getPassthroughPageUrl(uri, { url, customUrl }) {
   return bluebird.resolve(customUrl || url);
 }
 
+/**
+ * Allow a page to be published if it is dynamic. This allows the page
+ * to be published, but the pages service has the logic to not create
+ * a _uri to point to the page
+ *
+ * @param  {String} uri
+ * @param  {Boolean|Undefined} _dynamic
+ * @return {Promise}
+ */
+function publishDynamicPage(uri, { _dynamic }) {
+  if (!_dynamic || typeof _dynamic !== 'boolean') {
+    return bluebird.reject(new Error('Page is not dynamic'));
+  }
+
+  return bluebird.resolve(_dynamic);
+}
 
 /**
  * Always do these actins when publishing a page
@@ -124,6 +140,11 @@ function publishPageAtUrl(url, uri, data, locals, site) { // eslint-disable-line
   // So a url can still be derived from rules unique to the
   // implementation, but customUrl should override those rules
   url = data.customUrl || url;
+
+  if (data._dynamic) {
+    locals.publishUrlDynamic = true;
+    return data;
+  }
 
   return updatePageAndLocalsWithUrl(url, data, locals)
     .then(url => storeUrlHistory(url, uri, data))
@@ -164,8 +185,7 @@ function resolvePublishUrl(uri, locals, site) {
 
     if (useResolvePublishUrl) {
       // Allow a site to add or modify the publishing chain
-      publishingChain = publishingChain.concat(site.resolvePublishUrl);
-      publishingChain.push(getPassthroughPageUrl); // We always want to make sure we get a page url
+      publishingChain = publishingChain.concat(site.resolvePublishUrl, [getPassthroughPageUrl, publishDynamicPage]);
     }
 
     if ( publishingChain.length > 0 ) {
@@ -182,4 +202,5 @@ module.exports = resolvePublishUrl;
 
 // For testing
 module.exports.getPassthroughPageUrl = getPassthroughPageUrl;
+module.exports.publishDynamicPage = publishDynamicPage;
 module.exports.modifyPublishedData = modifyPublishedData;

--- a/lib/services/publish.js
+++ b/lib/services/publish.js
@@ -142,7 +142,7 @@ function publishPageAtUrl(url, uri, data, locals, site) { // eslint-disable-line
   url = data.customUrl || url;
 
   if (data._dynamic) {
-    locals.publishUrlDynamic = true;
+    locals.isDynamicPublishUrl = true;
     return data;
   }
 

--- a/lib/services/publish.test.js
+++ b/lib/services/publish.test.js
@@ -130,7 +130,7 @@ describe(_.startCase(filename), function () {
       return lib('some/uri', locals, fakeSite)(_.cloneDeep(fakePage))
         .then(function (resp) {
           expect(resp._dynamic).to.be.true;
-          expect(locals.publishUrlDynamic).to.be.true;
+          expect(locals.isDynamicPublishUrl).to.be.true;
         });
     });
   });

--- a/lib/services/publish.test.js
+++ b/lib/services/publish.test.js
@@ -122,6 +122,17 @@ describe(_.startCase(filename), function () {
           expect(resp).to.eql(_.assign(fakePage, {urlHistory: [fakeUrl]}));
         });
     });
+
+    it('allows for publishing a dynamic page', function () {
+      const fakePage = {page: 'data', _dynamic: true},
+        locals = {};
+
+      return lib('some/uri', locals, fakeSite)(_.cloneDeep(fakePage))
+        .then(function (resp) {
+          expect(resp._dynamic).to.be.true;
+          expect(locals.publishUrlDynamic).to.be.true;
+        });
+    });
   });
 
   describe('modifyPublishedData', function () {
@@ -168,6 +179,32 @@ describe(_.startCase(filename), function () {
       return fn('a/uri', {url: 'cool/url'})
         .then(function (resp) {
           expect(resp).to.equal('cool/url');
+        });
+    });
+  });
+
+  describe('publishDynamicPage', function () {
+    const fn = lib[this.title];
+
+    it('rejects if _dynamic is not defined', function () {
+      return fn('some/_pages/uri', {})
+        .catch(err => {
+          expect(err.message).to.eql('Page is not dynamic');
+        });
+    });
+
+    it('rejects if _dynamic is not a boolean defined', function () {
+      return fn('some/_pages/uri', {_dynamic: 'true'})
+        .catch(err => {
+          expect(err.message).to.eql('Page is not dynamic');
+        });
+    });
+
+    it('resolves true when _dynamic is a truthy boolean', function () {
+      return fn('some/_pages/uri', {_dynamic: true})
+        .then(resp => {
+          expect(typeof resp).to.equal('boolean');
+          expect(resp).to.be.true;
         });
     });
   });

--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -130,7 +130,7 @@ function urlToUri(url) {
  * @returns {object}
  */
 function omitPageConfiguration(pageData) {
-  return _.omit(pageData, ['layout', 'url', 'urlHistory', 'customUrl', 'lastModified', 'priority', 'changeFrequency']);
+  return _.omit(pageData, ['_dynamic', 'layout', 'url', 'urlHistory', 'customUrl', 'lastModified', 'priority', 'changeFrequency']);
 }
 
 /**


### PR DESCRIPTION
- Publishes a dynamic page if a `_dynamic` property is set to `true` on the page data
- If dynamic, a uri is not created
- Attaches `publishUrlDynamic` to `locals` to mimic `publishUrl`. It's very handy for processing data in a model.js `render` for a component when publishing