### PR TITLE
Meta Patch Requests

### DIFF
--- a/lib/routes/_layouts.js
+++ b/lib/routes/_layouts.js
@@ -15,9 +15,9 @@ let validation, route;
 
 /**
  * get composed component data
- * @param  {string} uri    of root component
+ * @param  {string} uri of root component
  * @param  {object} locals
- * @return {Promise}        composed data of root component and children
+ * @return {Promise} composed data of root component and children
  */
 function getComposed(uri, locals) {
   return controller.get(uri, locals).then(data => {
@@ -209,6 +209,15 @@ route = _.bindAll({
    */
   getMeta(req, res) {
     responses.expectJSON(() => metaController.getMeta(req.uri), res);
+  },
+
+  /**
+   *
+   * @param {*} req
+   * @param {*} res
+   */
+  patchMeta(req, res) {
+    responses.expectJSON(() => metaController.patchMeta(req.uri, req.body), res);
   }
 }, [
   'get',
@@ -222,7 +231,8 @@ route = _.bindAll({
   'schema',
   'render',
   'putMeta',
-  'getMeta'
+  'getMeta',
+  'patchMeta'
 ]);
 
 function routes(router) {
@@ -303,13 +313,16 @@ function routes(router) {
   router.delete('/:name/instances/:id', route.del);
 
   // Meta routes
-  router.all('/:name/instances/:id/meta', responses.methodNotAllowed({allow: ['get', 'put']}));
+  router.all('/:name/instances/:id/meta', responses.methodNotAllowed({allow: ['get', 'put', 'patch']}));
   router.all('/:name/instances/:id/meta', responses.notAcceptable({accept: ['application/json']}));
   router.all('/:name/instances/:id/meta', responses.denyTrailingSlashOnId);
   router.get('/:name/instances/:id/meta', route.getMeta);
   router.put('/:name/instances/:id/meta', responses.denyReferenceAtRoot);
   router.put('/:name/instances/:id/meta', withAuthLevel(authLevels.WRITE));
   router.put('/:name/instances/:id/meta', route.putMeta);
+  router.patch('/:name/instances/:id/meta', responses.denyReferenceAtRoot);
+  router.patch('/:name/instances/:id/meta', withAuthLevel(authLevels.WRITE));
+  router.patch('/:name/instances/:id/meta', route.patchMeta);
 
   // Need to have the delete route instance below or else it'll catch everything
   router.delete('/:name', withAuthLevel(authLevels.ADMIN));

--- a/lib/routes/_layouts.js
+++ b/lib/routes/_layouts.js
@@ -194,27 +194,33 @@ route = _.bindAll({
   },
 
   /**
-   * [putMeta description]
-   * @param  {[type]} req [description]
-   * @param  {[type]} res [description]
+   * Overwrite the metadata for a particular
+   * layout instance
+   *
+   * @param  {Object} req
+   * @param  {Object} res
    */
   putMeta(req, res) {
     responses.expectJSON(() => metaController.putMeta(req.uri, req.body), res);
   },
 
   /**
-   * [putMeta description]
-   * @param  {[type]} req [description]
-   * @param  {[type]} res [description]
+   * Retrieve the metadata for a particular
+   * layout instance
+   *
+   * @param  {Object} req
+   * @param  {Object} res
    */
   getMeta(req, res) {
     responses.expectJSON(() => metaController.getMeta(req.uri), res);
   },
 
   /**
+   * Overwrite the specific properties in the
+   * metadata for a particular layout instance
    *
-   * @param {*} req
-   * @param {*} res
+   * @param  {Object} req
+   * @param  {Object} res
    */
   patchMeta(req, res) {
     responses.expectJSON(() => metaController.patchMeta(req.uri, req.body), res);

--- a/lib/routes/_pages.js
+++ b/lib/routes/_pages.js
@@ -97,25 +97,31 @@ let route = _.bindAll({
     render.renderPage(req.uri, req, res, process.hrtime());
   },
   /**
-   * [putMeta description]
-   * @param  {[type]} req [description]
-   * @param  {[type]} res [description]
+   * Overwrite the metadata for a particular
+   * page instance
+   *
+   * @param  {Object} req
+   * @param  {Object} res
    */
   putMeta(req, res) {
     responses.expectJSON(() => metaController.putMeta(req.uri, req.body), res);
   },
   /**
-   * [putMeta description]
-   * @param  {[type]} req [description]
-   * @param  {[type]} res [description]
+   * Retrieve the metadata for a particular
+   * page instance
+   *
+   * @param  {Object} req
+   * @param  {Object} res
    */
   getMeta(req, res) {
     responses.expectJSON(() => metaController.getMeta(req.uri), res);
   },
   /**
+   * Overwrite the specific properties in the
+   * metadata for a particular page instance
    *
-   * @param {*} req
-   * @param {*} res
+   * @param  {Object} req
+   * @param  {Object} res
    */
   patchMeta(req, res) {
     responses.expectJSON(() => metaController.patchMeta(req.uri, req.body), res);

--- a/lib/routes/_pages.js
+++ b/lib/routes/_pages.js
@@ -111,6 +111,14 @@ let route = _.bindAll({
    */
   getMeta(req, res) {
     responses.expectJSON(() => metaController.getMeta(req.uri), res);
+  },
+  /**
+   *
+   * @param {*} req
+   * @param {*} res
+   */
+  patchMeta(req, res) {
+    responses.expectJSON(() => metaController.patchMeta(req.uri, req.body), res);
   }
 }, [
   'post',
@@ -119,7 +127,8 @@ let route = _.bindAll({
   'extension',
   'render',
   'putMeta',
-  'getMeta'
+  'getMeta',
+  'patchMeta'
 ]);
 
 function routes(router) {
@@ -161,13 +170,16 @@ function routes(router) {
   router.delete('/:name', withAuthLevel(authLevels.ADMIN));
   router.delete('/:name', responses.deleteRouteFromDB); // TODO: DELETE META AS WELL
 
-  router.all('/:name/meta', responses.methodNotAllowed({allow: ['get', 'put']}));
+  router.all('/:name/meta', responses.methodNotAllowed({allow: ['get', 'put', 'patch']}));
   router.all('/:name/meta', responses.notAcceptable({accept: ['application/json']}));
   router.all('/:name/meta', responses.denyTrailingSlashOnId);
   router.get('/:name/meta', route.getMeta);
   router.put('/:name/meta', responses.denyReferenceAtRoot);
   router.put('/:name/meta', withAuthLevel(authLevels.WRITE));
   router.put('/:name/meta', route.putMeta);
+  router.patch('/:name/meta', responses.denyReferenceAtRoot);
+  router.patch('/:name/meta', withAuthLevel(authLevels.WRITE));
+  router.patch('/:name/meta', route.patchMeta);
 }
 
 module.exports = routes;

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -2,12 +2,8 @@
 
 const _ = require('lodash'),
   jsonTransform = require('./../streams/json-transform'),
-<<<<<<< HEAD
-  promiseDefer = require('../utils/defer');
-=======
   promiseDefer = require('../utils/defer'),
   { replaceVersion } = require('clayutils');
->>>>>>> meta-and-layouts
 
 /**
  * Use ES6 promises

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -8,7 +8,8 @@ const _ = require('lodash'),
 
 /**
  *
- * @param {*} user
+ * @param {Object} user
+ * @returns {Object}
  */
 function userOrRobot(user) {
   if (user && _.get(user, 'username') && _.get(user, 'provider')) {
@@ -98,8 +99,6 @@ function publishLayout(ref, user) {
   return putMeta(ref, meta);
 }
 
-
-
 /**
  *
  * @param {*} uri
@@ -117,47 +116,14 @@ function unpublishPage(uri, user) {
 }
 
 /**
- * Merge some very specific properties of new and
- * old meta data. This is important to preserve
- * published time and history
  *
- * @param {Object} old
- * @param {Object} updated
- * @returns {Object}
+ * @param {*} uri
  */
-function mergeNewAndOldMeta(old, updated) {
-  const merged = {
-    firstPublishTime: old.firstPublishTime || updated.publishTime
+function pubToBus(uri) {
+  return (data) => {
+    bus.publish('saveMeta', JSON.stringify({ uri, data }));
+    return data;
   };
-
-  if (!Object.keys(old).length) {
-    return updated;
-  }
-
-  if (old.history && updated.history) {
-    merged.history = old.history.concat(updated.history);
-  }
-
-  return Object.assign(old, updated, merged);
-}
-
-/**
- * Write the page's meta object to the DB
- *
- * @param {String} uri
- * @param {Object} newData
- * @returns {Promise}
- */
-function putMeta(uri, newData) {
-  const id = replaceVersion(uri.replace('/meta', ''));
-
-  return getMeta(id)
-    .then(existing => db.putMeta(id, mergeNewAndOldMeta(existing, newData)))
-    .then(data => {
-      bus.publish('saveMeta', JSON.stringify({ uri: id, data }));
-
-      return data;
-    });
 }
 
 /**
@@ -173,8 +139,36 @@ function getMeta(uri) {
     .catch(() => ({}));
 }
 
+/**
+ * Write the page's meta object to the DB
+ *
+ * @param {String} uri
+ * @param {Object} data
+ * @returns {Promise}
+ */
+function putMeta(uri, data) {
+  const id = replaceVersion(uri.replace('/meta', ''));
+
+  return db.putMeta(id, data)
+    .then(pubToBus(id));
+}
+
+/**
+ *
+ * @param {*} uri
+ * @param {*} data
+ */
+function patchMeta(uri, data) {
+  const id = replaceVersion(uri.replace('/meta', ''));
+
+  return db.patchMeta(id, data)
+    .then(() => getMeta(uri))
+    .then(pubToBus(id));
+}
+
 module.exports.getMeta = getMeta;
 module.exports.putMeta = putMeta;
+module.exports.patchMeta = patchMeta;
 module.exports.createPage = createPage;
 module.exports.createLayout = createLayout;
 module.exports.publishPage = publishPage;

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -116,8 +116,11 @@ function unpublishPage(uri, user) {
 }
 
 /**
+ * Publish the `saveMeta` topic to
+ * the event bus
  *
- * @param {*} uri
+ * @param {String} uri
+ * @returns {Function}
  */
 function pubToBus(uri) {
   return (data) => {
@@ -154,9 +157,12 @@ function putMeta(uri, data) {
 }
 
 /**
+ * Update a subset of properties on
+ * a metadata object
  *
- * @param {*} uri
- * @param {*} data
+ * @param {String} uri
+ * @param {Object} data
+ * @returns {Promise}
  */
 function patchMeta(uri, data) {
   const id = replaceVersion(uri.replace('/meta', ''));


### PR DESCRIPTION
Adds `PATCH` handlers for meta endpoints for pages/layouts.

The actual update of the page is handled by the storage service.