### PR TITLE
Add site path to redirects

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -53,7 +53,7 @@ function getPutOperation(name, thing) {
     thing = JSON.stringify(thing);
   }
 
-  return {type: 'put', key: name, value: thing};
+  return { type: 'put', key: name, value: thing };
 }
 
 /**
@@ -144,7 +144,6 @@ function applyPrefixToPages(bootstrap, site) {
   });
 }
 
-
 /**
  * @param {object} bootstrap
  * @param {object} site
@@ -219,15 +218,15 @@ function load(data, site) {
       components.getPutOperations(name, _.cloneDeep(item))
     ).then(_.flatten);
   });
-  promisePagesOps = saveObjects(`${prefix}/_pages/`, compData._pages, (name, item) => [ getPutOperation(name, item)]);
-  promiseUsersOps = saveObjects('', compData._users, (name, item) => [ getPutOperation(`/_users/${encode(`${item.username}@${item.provider}`)}`, item)]);
+  promisePagesOps = saveObjects(`${prefix}/_pages/`, compData._pages, (name, item) => [getPutOperation(name, item)]);
+  promiseUsersOps = saveObjects('', compData._users, (name, item) => [getPutOperation(`/_users/${encode(`${item.username}@${item.provider}`)}`, item)]);
 
   /* eslint max-params: ["error", 5] */
   return bluebird.join(promiseComponentsOps, promisePagesOps, promiseUrisOps, promiseListsOps, promiseUsersOps, function (componentsOps, pagesOps, urisOps, listsOps, userOps) {
     const flatComponentsOps = _.flatten(componentsOps),
       ops = flatComponentsOps.concat(_.flattenDeep(pagesOps.concat(urisOps, listsOps, userOps)));
 
-    return db.batch(ops, {fillCache: false, sync: false});
+    return db.batch(ops, { fillCache: false, sync: false });
   });
 }
 
@@ -326,9 +325,12 @@ function skipBootstrap() {
   return bluebird.resolve();
 }
 
-module.exports = function (runBootstrap = true) {
-  return runBootstrap ? bootrapSitesAndComponents() : skipBootstrap();
-};
+/**
+ * Bootstraps components or skip it.
+ * @param {boolean} [runBootstrap=true]
+ * @return {Promise}
+ */
+module.exports = (runBootstrap = true) => runBootstrap ? bootrapSitesAndComponents() : skipBootstrap();
 module.exports.bootstrapPath = bootstrapPath;
 
 // For testing

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -143,8 +143,8 @@ function addControllerRoutes(router) {
     pathRouter = express.Router();
 
     // assume json or text for anything in request bodies
-    pathRouter.use(require('body-parser').json({strict: true, type: 'application/json', limit: '50mb'}));
-    pathRouter.use(require('body-parser').text({type: 'text/*'}));
+    pathRouter.use(require('body-parser').json({ strict: true, type: 'application/json', limit: '50mb' }));
+    pathRouter.use(require('body-parser').text({ type: 'text/*' }));
 
     controller(pathRouter);
 
@@ -194,7 +194,7 @@ function addSiteController(router, site, providers) {
       }
 
       if (!_.isFunction(controller) && Array.isArray(controller.routes)) {
-        attachRoutes(router, controller.routes);
+        attachRoutes(router, controller.routes, site);
       }
 
       // Providers are the same across all sites, but this is a convenient
@@ -330,7 +330,8 @@ function addHost(options) {
 }
 
 /**
- * @param {express.Router} router  Often an express app.
+ * Loads sites config and attach the basic routes for each one.
+ * @param {express.Router} router - Often an express app.
  * @param {Array} [providers]
  * @param {Object} [sessionStore]
  * @param {Object} [cacheControl]
@@ -345,7 +346,7 @@ function loadFromConfig(router, providers, sessionStore, cacheControl) {
 
   // iterate through the hosts
   _.each(siteHosts, function (hostname) {
-    const sites = _.filter(sitesMap, {host: hostname}).sort(sortByDepthOfPath);
+    const sites = _.filter(sitesMap, { host: hostname }).sort(sortByDepthOfPath);
 
     addHost({
       router,
@@ -356,6 +357,7 @@ function loadFromConfig(router, providers, sessionStore, cacheControl) {
       cacheControl
     });
   });
+
   return router;
 }
 

--- a/lib/services/attachRoutes.js
+++ b/lib/services/attachRoutes.js
@@ -2,25 +2,68 @@
 
 const render = require('../render');
 
+/**
+ * Normalizes redirects path appending site's path to it on sub-sites' redirects.
+ * @param {String} redirect
+ * @param {Object} site
+ * @return {String}
+ */
+function normalizeRedirectPath(redirect, site) {
+  return site.path && !redirect.includes(site.path) ? `${site.path}${redirect}` : redirect;
+}
+
+/**
+ * Attaches a plain route to the router.
+ * @param {Router} router
+ * @param {Object} route
+ * @param {String} route.path
+ * @return {Router}
+ */
 function attachPlainRoute(router, { path }) {
   return router.get(path, render);
 }
 
-function attachRedirect(router, { path, redirect }) {
+/**
+ * Attaches a route with redirect to the router.
+ * @param {Router} router
+ * @param {Object} route
+ * @param {String} route.path
+ * @param {String} route.redirect
+ * @param {Object} site
+ * @return {Router}
+ */
+function attachRedirect(router, { path, redirect }, site) {
+  redirect = normalizeRedirectPath(redirect, site);
+
   return router.get(path, (req, res) => {
     res.redirect(301, redirect);
   });
 }
 
+/**
+ * Attaches a dynamic route to the router.
+ * @param {Router} router
+ * @param {Object} route
+ * @param {String} route.path
+ * @param {String} route.dynamicPage
+ * @return {Router}
+ */
 function attachDynamicRoute(router, { path, dynamicPage }) {
   return router.get(path, render.renderDynamicRoute(dynamicPage));
 }
 
-function parseHandler(router, routeObj) {
+/**
+ * Parses site route config object.
+ * @param {Router} router
+ * @param {Object} routeObj - Route config
+ * @param {Object} site
+ * @return {Router}
+ */
+function parseHandler(router, routeObj, site) {
   const { redirect, dynamicPage } = routeObj;
 
   if (redirect) {
-    return attachRedirect(router, routeObj);
+    return attachRedirect(router, routeObj, site);
   } else if (dynamicPage) {
     return attachDynamicRoute(router, routeObj); // Pass in the page ID
   } else {
@@ -28,12 +71,22 @@ function parseHandler(router, routeObj) {
   }
 }
 
-function attachRoutes(router, routes) {
-  for (let i = 0; i < routes.length; i++) {
-    parseHandler(router, routes[i]);
-  }
+/**
+ * Parses and attach all routes to the router.
+ * @param {Router} router
+ * @param {Object[]} routes
+ * @param {Object} site
+ * @return {Router}
+ */
+function attachRoutes(router, routes = [], site) {
+  routes.forEach((route) => {
+    parseHandler(router, route, site);
+  });
 
   return router;
 }
 
 module.exports = attachRoutes;
+
+// Exposed for testing
+module.exports.normalizeRedirectPath = normalizeRedirectPath;

--- a/lib/services/attachRoutes.test.js
+++ b/lib/services/attachRoutes.test.js
@@ -8,12 +8,14 @@ const _ = require('lodash'),
 
 describe(_.startCase(filename), function () {
   const testRoutes = [
-    { path: '/'},
-    { path: '/:foo'},
-    { path: '/section/'},
-    { path: '/section', redirect: '/section/'},
-    { path: '/news/:tag', dynamicPage: 'somePageId'}
-  ];
+      { path: '/' },
+      { path: '/:foo' },
+      { path: '/section/' },
+      { path: '/section', redirect: '/section/' },
+      { path: '/news/:tag', dynamicPage: 'somePageId' }
+    ],
+    siteConfigMock = {};
+
   let sandbox;
 
   beforeEach(function () {
@@ -35,13 +37,13 @@ describe(_.startCase(filename), function () {
           }
         };
 
-      lib(router, testRoutes);
+      lib(router, testRoutes, siteConfigMock);
       expect(paths.length).to.equal(testRoutes.length);
     });
 
     it('calls res.redirect if a redirect is specified', function () {
       const testRoutes = [
-          { path: '/section', redirect: '/section/'},
+          { path: '/section', redirect: '/section/' },
         ],
         fakeRes = {
           redirect: sandbox.spy()
@@ -54,8 +56,40 @@ describe(_.startCase(filename), function () {
           }
         };
 
-      lib(router, testRoutes);
+      lib(router, testRoutes, siteConfigMock);
       sinon.assert.calledOnce(fakeRes.redirect);
+    });
+  });
+
+  describe('normalizeRedirectPath', () => {
+    const mockSites = [
+      {
+        path: ''
+      },
+      {
+        path: '/some-path'
+      }
+    ];
+
+    it('should add path to redirect if site has a path', () => {
+      const redirect = '/some-redirect/',
+        site = mockSites[1];
+
+      expect(lib.normalizeRedirectPath(redirect, site)).to.equal('/some-path/some-redirect/');
+    });
+
+    it('should not add path to redirect if site has no path', () => {
+      const redirect = '/some-redirect/',
+        site = mockSites[0];
+
+      expect(lib.normalizeRedirectPath(redirect, site)).to.equal('/some-redirect/');
+    });
+
+    it('should not add path to redirect if redirect already has the path set', () => {
+      const redirect = '/some-path/some-redirect/',
+        site = mockSites[0];
+
+      expect(lib.normalizeRedirectPath(redirect, site)).to.equal('/some-path/some-redirect/');
     });
   });
 });

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -13,8 +13,8 @@ bluebird.config({
 });
 
 /**
- * optionally pass in an express app, templating engines, and/or providers
- * note: if no providers are passed in, amphora doesn't protect routes
+ * Optionally pass in an express app, templating engines, and/or providers
+ * note: if no providers are passed in, amphora doesn't protect routes.
  * @param {Object}  [options]
  * @param {Array}   [options.providers]
  * @param {Object}  [options.app]
@@ -55,7 +55,5 @@ module.exports = function (options = {}) {
   }
 
   // look for bootstraps in components
-  return internalBootstrap(bootstrap).then(function () {
-    return router;
-  });
+  return internalBootstrap(bootstrap).then(() => router);
 };


### PR DESCRIPTION
Normalizes `redirect` path when a site has a path in its `confi.yaml`.

Closes #557 