### PR TITLE
Decode The Path

### DIFF
--- a/lib/services/references.js
+++ b/lib/services/references.js
@@ -120,7 +120,7 @@ function urlToUri(url) {
   }
   parts = urlParse.parse(url);
 
-  return parts.hostname + parts.path;
+  return `${parts.hostname}${decodeURIComponent(parts.path)}`;
 }
 
 

--- a/lib/services/references.test.js
+++ b/lib/services/references.test.js
@@ -140,6 +140,10 @@ describe(_.startCase(filename), function () {
     it('converts with port', function () {
       expect(fn('http://localhost:3333/some-path')).to.equal('localhost/some-path');
     });
+
+    it('decodes characters that url.parse encodes', function () {
+      expect(fn('http://localhost:3333/author/person-l\'cool')).to.equal('localhost/author/person-l\'cool');
+    });
   });
 
   describe('listDeepObjects', function () {


### PR DESCRIPTION
So, when _uris are made for pages on publish the url to expose is passed through Node's [`url.parse`](https://nodejs.org/docs/latest-v8.x/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost) method which encodes the url's path. 

So if I want to publish to a url like `www.thecut.com/author/catie-l'heureux/`, the uri that's created only is encoded: `www.thecut.com/author/catie-l%27heureux/` and gets saved in the database as such.

Then when you request the public url...

1. you get a 404 because the that's base64 encoded contains the uri encoded url
OR
2. if you requested the uri encoded url, Express decodes the uri when it's exposed to Amphora and so you can't resolve the proper _uri.

Basically, decode the path of the url when you're making the _uri .