### PR TITLE
Bootstrap Empty Directory Logging

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -154,6 +154,7 @@ function getBootstrapFile(dir) {
   dir = path.join(path.resolve(dir), 'bootstrap');
 
   return h(readYamlOrYml(dir))
+    .compact()
     .map(yaml => ({ dir, yaml }))
     .compact();
 }
@@ -167,7 +168,16 @@ function getBootstrapFile(dir) {
  */
 function readYamlOrYml(filename) {
   return files.readFilePromise(`${filename}.yml`)
-    .catch(() => Promise.resolve(files.readFilePromise(`${filename}.yaml`)));
+    .catch(() => {
+      return Promise.resolve(
+        files.readFilePromise(`${filename}.yaml`)
+          .catch(() => {
+            let splitCmpt = filename.split('/');
+
+            log('warn', `Could not find bootstrap.(yml|yaml) at ${splitCmpt[splitCmpt.length - 2]}, component will not be bootstrapped`);
+            return false;
+          }));
+    });
 }
 
 /**
@@ -184,3 +194,4 @@ function skipBootstrap() {
 module.exports = (runBootstrap = true) => runBootstrap ? processBootstraps() : skipBootstrap();
 // For testing
 module.exports.setLog = mock => log = mock;
+module.exports.readYamlOrYml = readYamlOrYml;

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -44,6 +44,7 @@ describe(_.startCase(filename), function () {
     lib.setLog(fakeLog);
     sandbox.stub(siteService);
     siteService.sites.returns(_.cloneDeep(sitesFake));
+    sandbox.stub(files, 'readFilePromise');
 
     return db.clear();
   });
@@ -66,7 +67,6 @@ describe(_.startCase(filename), function () {
       sandbox.stub(files, 'getYaml');
       sandbox.stub(files, 'getComponents');
       sandbox.stub(files, 'getComponentPath').callsFake(_.identity);
-      sandbox.stub(files, 'readFilePromise');
     });
 
     it('skips running the bootstrap process if the `runBootstrap` bool is false', function () {
@@ -94,6 +94,20 @@ describe(_.startCase(filename), function () {
       return fn()
         .then(() => {
           sinon.assert.called(fakeLog);
+        });
+    });
+  });
+
+  describe('readYamlOrYml', function () {
+    const fn = lib[this.title];
+
+    it('logs when an empty directory exists and does not contain a bootstrap file', function () {
+      files.readFilePromise.returns(Promise.reject());
+
+      return fn('path/to/some/cmptorlayout/bootstrap')
+        .then(() => {
+          sinon.assert.calledOnce(fakeLog);
+          sinon.assert.calledWith(fakeLog, 'warn', 'Could not find bootstrap.(yml|yaml) at cmptorlayout, component will not be bootstrapped');
         });
     });
   });


### PR DESCRIPTION
If you have an empty directory where a file cannot be found, Amphora should tell you during bootstrapping.