### PR TITLE
Log when using the clientError response

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -318,6 +318,8 @@ function unauthorized(res) {
  * @param {object} res
  */
 function clientError(err, res) {
+  log('error', err.message, { stack: err.stack });
+
   // They know it's a 400 already, we don't need to repeat the fact that its an error.
   const message = removePrefix(err.message, ':'),
     code = 400;

--- a/lib/responses.test.js
+++ b/lib/responses.test.js
@@ -139,7 +139,7 @@ describe(_.startCase(filename), function () {
 
       expectStatus(res, 400);
       expectResult(res, 'sendStatus: whatever', function () {
-        expectNoLogging();
+        sinon.assert.calledWith(fakeLog, 'error');
         done();
       });
       fn(new Error('something'), res);


### PR DESCRIPTION
The `clientError` response type is used any time the error message might include the string `Client`, which is incredibly broad and additionally this response type does not initiate a log.  In an effort to fill in potentially useful but missing logs this change adds an error log when using `clientError`