### PR TITLE
Redirect From Published Meta

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -524,11 +524,27 @@ function deleteRouteFromDB(req, res) {
   }, res);
 }
 
+/**
+ * Forces a redirect back to the non-published
+ * version of a uri
+ *
+ * @param {Number} code
+ * @returns {Function}
+ */
+function forceDefault(code = 303) {
+  return (req, res) => {
+    res.redirect(code, `${res.locals.site.protocol}://${req.uri.replace('@published', '')}`);
+  };
+}
+
 // utility for routers
 module.exports.removeQueryString = removeQueryString;
 module.exports.removeExtension = removeExtension;
 module.exports.normalizePath = normalizePath;
 module.exports.getUri = getUri;
+
+// redirect responses
+module.exports.forceDefault = forceDefault;
 
 // error responses
 module.exports.clientError = clientError; // 400 client error

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -531,7 +531,7 @@ function deleteRouteFromDB(req, res) {
  * @param {Number} code
  * @returns {Function}
  */
-function forceDefault(code = 303) {
+function forceEditableInstance(code = 303) {
   return (req, res) => {
     res.redirect(code, `${res.locals.site.protocol}://${req.uri.replace('@published', '')}`);
   };
@@ -544,7 +544,7 @@ module.exports.normalizePath = normalizePath;
 module.exports.getUri = getUri;
 
 // redirect responses
-module.exports.forceDefault = forceDefault;
+module.exports.forceEditableInstance = forceEditableInstance;
 
 // error responses
 module.exports.clientError = clientError; // 400 client error

--- a/lib/routes/_layouts.js
+++ b/lib/routes/_layouts.js
@@ -307,7 +307,7 @@ function routes(router) {
 
   // Meta routes
   router.all('/:name/instances/:id@published/meta', responses.methodNotAllowed({allow: ['get']}));
-  router.get('/:name/instances/:id@published/meta', responses.forceDefault());
+  router.get('/:name/instances/:id@published/meta', responses.forceEditableInstance());
 
   router.all('/:name/instances/:id/meta', responses.methodNotAllowed({allow: ['get', 'put', 'patch']}));
   router.all('/:name/instances/:id/meta', responses.notAcceptable({accept: ['application/json']}));

--- a/lib/routes/_layouts.js
+++ b/lib/routes/_layouts.js
@@ -212,6 +212,17 @@ route = _.bindAll({
    */
   patchMeta(req, res) {
     responses.expectJSON(() => metaController.patchMeta(req.uri, req.body), res);
+  },
+
+  /**
+   * Forces request to the default instance of the page
+   * when requesting the /meta endpoint
+   *
+   * @param {Object} req
+   * @param {Object} res
+   */
+  forceEditablePageMeta(req, res) {
+    res.redirect(303, `${res.locals.site.protocol}://${req.uri.replace('@published', '')}`);
   }
 }, [
   'get',
@@ -225,7 +236,8 @@ route = _.bindAll({
   'render',
   'putMeta',
   'getMeta',
-  'patchMeta'
+  'patchMeta',
+  'forceEditablePageMeta'
 ]);
 
 function routes(router) {
@@ -237,7 +249,7 @@ function routes(router) {
   router.all('/', responses.methodNotAllowed({
     allow: ['get']
   }));
-  //     accept: ['application/json']
+
   router.all('/', responses.notAcceptable({
     accept: ['application/json']
   }));
@@ -306,6 +318,9 @@ function routes(router) {
   router.delete('/:name/instances/:id', responses.deleteRouteFromDB);
 
   // Meta routes
+  router.all('/:name/instances/:id@published/meta', responses.methodNotAllowed({allow: ['get']}));
+  router.get('/:name/instances/:id@published/meta', route.forceEditablePageMeta);
+
   router.all('/:name/instances/:id/meta', responses.methodNotAllowed({allow: ['get', 'put', 'patch']}));
   router.all('/:name/instances/:id/meta', responses.notAcceptable({accept: ['application/json']}));
   router.all('/:name/instances/:id/meta', responses.denyTrailingSlashOnId);

--- a/lib/routes/_layouts.js
+++ b/lib/routes/_layouts.js
@@ -212,17 +212,6 @@ route = _.bindAll({
    */
   patchMeta(req, res) {
     responses.expectJSON(() => metaController.patchMeta(req.uri, req.body), res);
-  },
-
-  /**
-   * Forces request to the default instance of the page
-   * when requesting the /meta endpoint
-   *
-   * @param {Object} req
-   * @param {Object} res
-   */
-  forceEditablePageMeta(req, res) {
-    res.redirect(303, `${res.locals.site.protocol}://${req.uri.replace('@published', '')}`);
   }
 }, [
   'get',
@@ -236,8 +225,7 @@ route = _.bindAll({
   'render',
   'putMeta',
   'getMeta',
-  'patchMeta',
-  'forceEditablePageMeta'
+  'patchMeta'
 ]);
 
 function routes(router) {
@@ -319,7 +307,7 @@ function routes(router) {
 
   // Meta routes
   router.all('/:name/instances/:id@published/meta', responses.methodNotAllowed({allow: ['get']}));
-  router.get('/:name/instances/:id@published/meta', route.forceEditablePageMeta);
+  router.get('/:name/instances/:id@published/meta', responses.forceDefault());
 
   router.all('/:name/instances/:id/meta', responses.methodNotAllowed({allow: ['get', 'put', 'patch']}));
   router.all('/:name/instances/:id/meta', responses.notAcceptable({accept: ['application/json']}));

--- a/lib/routes/_pages.js
+++ b/lib/routes/_pages.js
@@ -121,6 +121,16 @@ let route = _.bindAll({
    */
   patchMeta(req, res) {
     responses.expectJSON(() => metaController.patchMeta(req.uri, req.body), res);
+  },
+  /**
+   * Forces request to the default instance of the page
+   * when requesting the /meta endpoint
+   *
+   * @param {Object} req
+   * @param {Object} res
+   */
+  forceEditablePageMeta(req, res) {
+    res.redirect(303, `${res.locals.site.protocol}://${req.uri.replace('@published', '')}`);
   }
 }, [
   'post',
@@ -130,7 +140,8 @@ let route = _.bindAll({
   'render',
   'putMeta',
   'getMeta',
-  'patchMeta'
+  'patchMeta',
+  'forceEditablePageMeta'
 ]);
 
 function routes(router) {
@@ -171,6 +182,9 @@ function routes(router) {
   router.put('/:name', route.putLatest);
   router.delete('/:name', withAuthLevel(authLevels.ADMIN));
   router.delete('/:name', responses.deleteRouteFromDB); // TODO: DELETE META AS WELL
+
+  router.all('/:name@published/meta', responses.methodNotAllowed({allow: ['get']}));
+  router.get('/:name@published/meta', route.forceEditablePageMeta);
 
   router.all('/:name/meta', responses.methodNotAllowed({allow: ['get', 'put', 'patch']}));
   router.all('/:name/meta', responses.notAcceptable({accept: ['application/json']}));

--- a/lib/routes/_pages.js
+++ b/lib/routes/_pages.js
@@ -173,7 +173,7 @@ function routes(router) {
   router.delete('/:name', responses.deleteRouteFromDB); // TODO: DELETE META AS WELL
 
   router.all('/:name@published/meta', responses.methodNotAllowed({allow: ['get']}));
-  router.get('/:name@published/meta', responses.forceDefault());
+  router.get('/:name@published/meta', responses.forceEditableInstance());
 
   router.all('/:name/meta', responses.methodNotAllowed({allow: ['get', 'put', 'patch']}));
   router.all('/:name/meta', responses.notAcceptable({accept: ['application/json']}));

--- a/lib/routes/_pages.js
+++ b/lib/routes/_pages.js
@@ -121,16 +121,6 @@ let route = _.bindAll({
    */
   patchMeta(req, res) {
     responses.expectJSON(() => metaController.patchMeta(req.uri, req.body), res);
-  },
-  /**
-   * Forces request to the default instance of the page
-   * when requesting the /meta endpoint
-   *
-   * @param {Object} req
-   * @param {Object} res
-   */
-  forceEditablePageMeta(req, res) {
-    res.redirect(303, `${res.locals.site.protocol}://${req.uri.replace('@published', '')}`);
   }
 }, [
   'post',
@@ -140,8 +130,7 @@ let route = _.bindAll({
   'render',
   'putMeta',
   'getMeta',
-  'patchMeta',
-  'forceEditablePageMeta'
+  'patchMeta'
 ]);
 
 function routes(router) {
@@ -184,7 +173,7 @@ function routes(router) {
   router.delete('/:name', responses.deleteRouteFromDB); // TODO: DELETE META AS WELL
 
   router.all('/:name@published/meta', responses.methodNotAllowed({allow: ['get']}));
-  router.get('/:name@published/meta', route.forceEditablePageMeta);
+  router.get('/:name@published/meta', responses.forceDefault());
 
   router.all('/:name/meta', responses.methodNotAllowed({allow: ['get', 'put', 'patch']}));
   router.all('/:name/meta', responses.notAcceptable({accept: ['application/json']}));

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -110,9 +110,10 @@ function getLatestData(uri) {
 }
 
 /**
- * [registerStorage description]
- * @param  {[type]} storage [description]
- * @return {[type]}         [description]
+ * Register the storage module by assigning its
+ * methods to the exports of the internal db module
+ *
+ * @param  {Object} storage
  */
 function registerStorage(storage) {
   for (let action in storage) {

--- a/test/api/_layouts/get.js
+++ b/test/api/_layouts/get.js
@@ -11,6 +11,7 @@ describe(endpointName, function () {
     let sandbox,
       hostname = 'localhost.example.com',
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptRedirect = apiAccepts.acceptRedirect(_.camelCase(filename)),
       data = { main: 'main' },
       deepData = { d: 'e' },
       cascadingData = ref => {
@@ -146,6 +147,16 @@ describe(endpointName, function () {
       });
 
       acceptsJson(path, { name: 'valid', id: 'valid' }, 200, {});
+    });
+
+    describe('/_layouts/:name/instances/:id@published/meta', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptRedirect(path, { name: 'valid', id: 'valid' }, 303, {});
     });
   });
 });

--- a/test/api/_pages/get.js
+++ b/test/api/_pages/get.js
@@ -11,6 +11,7 @@ describe(endpointName, function () {
     let sandbox,
       hostname = 'localhost.example.com',
       acceptsJson = apiAccepts.acceptsJson(_.camelCase(filename)),
+      acceptRedirect = apiAccepts.acceptRedirect(_.camelCase(filename)),
       pageData = { layout: 'localhost.example.com/_components/layout', center: ['localhost.example.com/_components/valid'] },
       layoutData = { center: 'center', deep: [{_ref: 'localhost.example.com/_components/validDeep'}] },
       deepData = { _ref: 'localhost.example.com/_components/validDeep' },
@@ -125,6 +126,16 @@ describe(endpointName, function () {
       });
 
       acceptsJson(path, { name: 'valid' }, 200, {});
+    });
+
+    describe('/_pages/:name@published/meta', function () {
+      const path = this.title;
+
+      beforeEach(function () {
+        return apiAccepts.beforeEachTest({ sandbox, hostname });
+      });
+
+      acceptRedirect(path, { name: 'valid' }, 303, {});
     });
   });
 });

--- a/test/fixtures/api-accepts.js
+++ b/test/fixtures/api-accepts.js
@@ -54,8 +54,11 @@ function createTest(options) {
       .set('Host', host)
       .set('Authorization', 'token testKey');
 
-    promise = promise.expect('Content-Type', options.contentType)
-      .expect(options.status);
+    if (options.contentType) {
+      promise = promise.expect('Content-Type', options.contentType);
+    }
+
+    promise = promise.expect(options.status);
 
     if (options.data !== undefined) {
       promise = promise.expect(options.data);
@@ -151,6 +154,25 @@ function acceptsJson(method) {
       status,
       accept: 'application/json',
       contentType: /json/
+    });
+  };
+}
+
+/**
+ * Create a generic test that accepts JSON
+ * @param {String} method
+ * @returns {Function}
+ */
+function acceptRedirect(method) {
+  return function (path, replacements, status, data) {
+    createTest({
+      description: JSON.stringify(replacements) + ' receives a redirect',
+      path,
+      method,
+      replacements,
+      data,
+      status,
+      accept: '*/*'
     });
   };
 }
@@ -533,6 +555,7 @@ module.exports.setApp = setApp;
 module.exports.setHost = setHost;
 module.exports.acceptsHtml = acceptsHtml;
 module.exports.acceptsHtmlBody = acceptsHtmlBody;
+module.exports.acceptRedirect = acceptRedirect;
 module.exports.acceptsJson = acceptsJson;
 module.exports.acceptsJsonBody = acceptsJsonBody;
 module.exports.acceptsText = acceptsText;


### PR DESCRIPTION
Requests to `/_pages/:id@published/meta` are redirected to `/_pages/:id/meta` so that the same data is not accessible in two locations.

- Fixes lint issue
- Adds testing helper for testing redirects
- Redirect logic for layouts and pages