### PR TITLE
Event Bus Plugin

### DIFF
--- a/lib/routes/_layouts.js
+++ b/lib/routes/_layouts.js
@@ -108,7 +108,7 @@ route = _.bindAll({
         .catch(() => {
           return controller.put(uri, data, res.locals)
             .then(resp => metaController.createLayout(uri, user).then(() => {
-              bus.publish('createLayout', JSON.stringify({ uri, data, user }));
+              bus.publish('createLayout', { uri, data, user });
               return resp;
             }));
         });

--- a/lib/routes/_users.js
+++ b/lib/routes/_users.js
@@ -44,7 +44,7 @@ let route = _.bindAll({
         .then(oldData => {
           return db.del(req.uri)
             .then(() => {
-              bus.publish('deleteUser', JSON.stringify({ uri: req.uri }));
+              bus.publish('deleteUser', { uri: req.uri });
               return oldData;
             });
         });

--- a/lib/services/bus.js
+++ b/lib/services/bus.js
@@ -7,6 +7,8 @@ var log = require('./logger').setup({ file: __filename }),
 
 /**
  * Connect to the bus Redis instance
+ *
+ * @param {Object} busModule
  */
 function connect(busModule) {
   if (busModule) {

--- a/lib/services/bus.js
+++ b/lib/services/bus.js
@@ -7,9 +7,13 @@ var log = require('./logger').setup({ file: __filename });
 /**
  * Connect to the bus Redis instance
  */
-function connect() {
-  log('info', `Connecting to Redis Event Bus at ${process.env.CLAY_BUS_HOST}`);
-  module.exports.client = new Redis(process.env.CLAY_BUS_HOST);
+function connect(busModule) {
+  if (busModule) {
+    busModule.connect();
+  } else {
+    log('info', `Connecting to default Redis event bus at ${process.env.CLAY_BUS_HOST}`);
+    module.exports.client = new Redis(process.env.CLAY_BUS_HOST);
+  }
 }
 
 /**

--- a/lib/services/bus.js
+++ b/lib/services/bus.js
@@ -2,14 +2,16 @@
 
 const Redis = require('ioredis'),
   NAMESPACE = process.env.CLAY_BUS_NAMESPACE || 'clay';
-var log = require('./logger').setup({ file: __filename });
+var log = require('./logger').setup({ file: __filename }),
+  BUS_MODULE = false;
 
 /**
  * Connect to the bus Redis instance
  */
 function connect(busModule) {
   if (busModule) {
-    busModule.connect();
+    module.exports.client = busModule.connect();
+    BUS_MODULE = true;
   } else {
     log('info', `Connecting to default Redis event bus at ${process.env.CLAY_BUS_HOST}`);
     module.exports.client = new Redis(process.env.CLAY_BUS_HOST);
@@ -23,12 +25,14 @@ function connect(busModule) {
  * @param  {String} msg
  */
 function publish(topic, msg) {
-  if (!topic || !msg || typeof topic !== 'string' || typeof msg !== 'string') {
-    throw new Error('A `topic` and `msg` property must be defined and both must be strings');
+  if (!topic || !msg || typeof topic !== 'string' || typeof msg !== 'object') {
+    throw new Error('A `topic` (string) and `msg` (object) property must be defined');
   }
 
-  if (module.exports.client) {
+  if (module.exports.client && BUS_MODULE) {
     module.exports.client.publish(`${NAMESPACE}:${topic}`, msg);
+  } else if (module.exports.client) {
+    module.exports.client.publish(`${NAMESPACE}:${topic}`, JSON.stringify(msg));
   }
 }
 
@@ -37,3 +41,4 @@ module.exports.publish = publish;
 
 // For testing
 module.exports.client = undefined;
+module.exports.setLog = mock => log = mock;

--- a/lib/services/bus.test.js
+++ b/lib/services/bus.test.js
@@ -8,13 +8,15 @@ const _ = require('lodash'),
   Redis = require('ioredis');
 
 describe(_.startCase(filename), function () {
-  var sandbox, publish;
+  var sandbox, publish, fakeLog;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
     sandbox.stub(Redis.prototype, 'connect');
     publish = sandbox.stub();
+    fakeLog = sandbox.stub();
     lib.client = { publish };
+    lib.setLog(fakeLog);
   });
 
   afterEach(function () {
@@ -32,7 +34,8 @@ describe(_.startCase(filename), function () {
   });
 
   describe('publish', function () {
-    const fn = lib[this.title];
+    const fn = lib[this.title],
+      testObj = { foo: 'bar' };
 
     it('throws an error if topic and message are not defined', function () {
       expect(fn).to.throw();
@@ -46,15 +49,24 @@ describe(_.startCase(filename), function () {
       expect(() => fn('foo', 1)).to.throw();
     });
 
-    it('calls the publish function if topic and string pass validation', function () {
-      fn('foo', 'bar');
+    it('calls the publish function if topic and message pass validation', function () {
+      fn('foo', testObj);
       sinon.assert.calledOnce(publish);
     });
 
     it('does not call publish if no client is defined', function () {
       lib.client = false;
-      fn('foo', 'bar');
+      fn('foo', testObj);
       sinon.assert.notCalled(publish);
+    });
+
+    it('accepts a bus module passed into the connect method', function () {
+      const fakePub = sandbox.spy(),
+        fakeBus = { connect: () => ({ publish: fakePub })};
+
+      lib.connect(fakeBus);
+      fn('foo', testObj);
+      sinon.assert.calledOnce(fakePub);
     });
   });
 });

--- a/lib/services/db-operations.js
+++ b/lib/services/db-operations.js
@@ -125,7 +125,7 @@ function cascadingPut(putFn) {
 
       // return ops if successful
       return db.batch(ops)
-        .then(() => bus.publish('save', JSON.stringify(ops)))
+        .then(() => bus.publish('save', ops))
         .then(() => {
           // return the value of the last batch operation (the root object) if successful
           const rootOp = _.last(ops);

--- a/lib/services/layouts.js
+++ b/lib/services/layouts.js
@@ -66,7 +66,7 @@ function publish(uri, data, locals) {
     return dbOps.cascadingPut(put)(uri, data, locals)
       .then(data => meta.publishLayout(uri, user)
         .then(() => {
-          bus.publish('publishLayout', JSON.stringify({ uri, data, user }));
+          bus.publish('publishLayout', { uri, data, user });
           return data;
         }));
   }
@@ -75,7 +75,7 @@ function publish(uri, data, locals) {
     .then(latestData => composer.resolveComponentReferences(latestData, locals, composer.filterBaseInstanceReferences))
     .then(versionedData => dbOps.cascadingPut(put)(uri, versionedData, locals))
     .then(data => meta.publishLayout(uri, user).then(() => {
-      bus.publish('publishLayout', JSON.stringify({ uri, data, user }));
+      bus.publish('publishLayout', { uri, data, user });
       return data;
     }));
 }
@@ -97,7 +97,7 @@ function post(uri, data, locals) {
 
       return meta.createLayout(uri, user)
         .then(() => {
-          bus.publish('createLayout', JSON.stringify({ uri, data, user }));
+          bus.publish('createLayout', { uri, data, user });
           return result;
         });
     });

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -142,7 +142,7 @@ function unpublishPage(uri, user) {
  */
 function pubToBus(uri) {
   return (data) => {
-    bus.publish('saveMeta', JSON.stringify({ uri, data }));
+    bus.publish('saveMeta', { uri, data });
     return data;
   };
 }

--- a/lib/services/models.js
+++ b/lib/services/models.js
@@ -66,10 +66,6 @@ function get(model, renderModel, executeRender, uri, locals) { /* eslint max-par
 
     promise = bluebird.try(() => {
       return db.get(uri)
-        // .then(data => {
-        //   console.log(data);
-        //   return data;
-        // })
         .then(upgrade.init(uri, locals)) // Run an upgrade!
         .then(data => model.render(uri, data, locals));
     }).tap(result => {

--- a/lib/services/models.js
+++ b/lib/services/models.js
@@ -66,6 +66,10 @@ function get(model, renderModel, executeRender, uri, locals) { /* eslint max-par
 
     promise = bluebird.try(() => {
       return db.get(uri)
+        // .then(data => {
+        //   console.log(data);
+        //   return data;
+        // })
         .then(upgrade.init(uri, locals)) // Run an upgrade!
         .then(data => model.render(uri, data, locals));
     }).tap(result => {

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -103,7 +103,7 @@ function getPageClonePutOperations(pageData, locals) {
  */
 function applyBatch(ops) {
   return db.batch(ops)
-    .then(() => bus.publish('save', JSON.stringify(ops)))
+    .then(() => bus.publish('save', ops))
     .then(() => {
       const lastOp = _.last(ops);
 
@@ -274,7 +274,7 @@ function publish(uri, data, locals) {
     .then(publishedData => {
       return meta.publishPage(uri, publishedMeta, user).then(() => {
         // Notify the bus
-        bus.publish('publishPage', JSON.stringify({ uri, data: publishedData, user}));
+        bus.publish('publishPage', { uri, data: publishedData, user});
 
         notifications.notify(site, 'published', publishedData);
         // Update the meta object
@@ -315,7 +315,7 @@ function create(uri, data, locals) {
 
       return meta.createPage(newPage._ref, user)
         .then(() => {
-          bus.publish('createPage', JSON.stringify({ uri: pageReference, data: newPage, user }));
+          bus.publish('createPage', { uri: pageReference, data: newPage, user });
 
           return newPage;
         });
@@ -346,7 +346,7 @@ function putLatest(uri, data, locals) {
       return db.put(uri, JSON.stringify(data))
         .then(() => meta.createPage(uri, user))
         .then(() => {
-          bus.publish('createPage', JSON.stringify({ uri, data, user }));
+          bus.publish('createPage', { uri, data, user });
 
           return data;
         });

--- a/lib/services/uris.js
+++ b/lib/services/uris.js
@@ -48,7 +48,7 @@ function del(uri, user) {
         site = siteService.getSiteFromPrefix(prefix),
         pageUrl = buf.decode(uri.split('/').pop());
 
-      bus.publish('unpublishPage', JSON.stringify({ uri: oldPageUri, url: pageUrl, user }));
+      bus.publish('unpublishPage', { uri: oldPageUri, url: pageUrl, user });
       notifications.notify(site, 'unpublished', { url: pageUrl, uri: oldPageUri });
       return meta.unpublishPage(oldPageUri, user)
         .then(() => oldPageUri);

--- a/lib/services/users.js
+++ b/lib/services/users.js
@@ -49,7 +49,7 @@ function createUser(data) {
   return db.put(uri, JSON.stringify(data)).then(() => {
     data._ref = uri;
 
-    bus.publish('saveUser', JSON.stringify({ key: uri, value: data }));
+    bus.publish('saveUser', { key: uri, value: data });
     return data;
   });
 }

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -34,7 +34,8 @@ module.exports = function (options = {}) {
       renderers,
       plugins = [],
       bootstrap = true,
-      storage = false
+      storage = false,
+      eventBus = false
     } = options, router;
 
   if (!storage) {
@@ -42,7 +43,7 @@ module.exports = function (options = {}) {
   }
 
   if (process.env.CLAY_BUS_HOST) {
-    bus.connect();
+    bus.connect(eventBus);
   }
 
   // if engines were passed in, send them to the renderer

--- a/test/index.js
+++ b/test/index.js
@@ -20,12 +20,10 @@ require('..');
 require('../lib/services/db.test');
 
 _.each(apiTests, test => {
-  // if (_.includes(test, 'api/_pages/put')) require(test);
   require(test);
 });
 
 _.each(tests, test => {
-  // if (_.includes(test, 'services/publish.test')) require(test);
   require(test);
 });
 


### PR DESCRIPTION
Allows a custom event bus to be passed in and invoked in the same way the built-in event bus is triggered.

In order to provide a more robust plugin API, the stringification of the bus message is moved to the bus service itself. It should be the choice of the plugin how to stringify the message.