### PR TITLE
Return 404 error when targeting a non-existent instance of a component

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -87,13 +87,11 @@ function renderComponent(req, res, hrStart) {
   return components.get(_ref, locals)
     .then(cmptData => formDataForRenderer(cmptData, { _ref }, locals))
     .tap(logTime(hrStart, _ref))
-    .then(({data, options}) => renderer.render(data, options, res))
+    .then(({ data, options }) => renderer.render(data, options, res))
     .catch(err => {
-      const errorHandler = responses.handleError(res);
-
       log('error', err);
 
-      return errorHandler(err);
+      return responses.handleError(res)(err);
     });
 }
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -88,7 +88,13 @@ function renderComponent(req, res, hrStart) {
     .then(cmptData => formDataForRenderer(cmptData, { _ref }, locals))
     .tap(logTime(hrStart, _ref))
     .then(({data, options}) => renderer.render(data, options, res))
-    .catch(err => log('error', err));
+    .catch(err => {
+      const errorHandler = responses.handleError(res);
+
+      log('error', err);
+
+      return errorHandler(err);
+    });
 }
 
 /**

--- a/lib/render.test.js
+++ b/lib/render.test.js
@@ -7,6 +7,7 @@ const _ = require('lodash'),
   expect = require('chai').expect,
   sinon = require('sinon'),
   schema = require('./schema'),
+  responses = require('./responses'),
   components = require('./services/components'),
   composer = require('./services/composer'),
   createMockReq = require('../test/fixtures/mocks/req'),
@@ -81,6 +82,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(components);
     sandbox.stub(composer);
     sandbox.stub(schema);
+    sandbox.stub(responses, 'handleError').returns(() => {});
     lib.setLog(mockLog);
     lib.resetUriRouteHandlers();
     lib.registerRenderers({
@@ -177,6 +179,7 @@ describe(_.startCase(filename), function () {
       return fn(req, getMockRes())
         .then(() => {
           sinon.assert.calledWith(mockLog, 'error', error);
+          sinon.assert.calledOnce(responses.handleError);
           lib.registerRenderers(undefined);
         });
     });


### PR DESCRIPTION
**Description:**
- Return `404` error when targeting a non-existent instance of a component with a renderer.

**Context:**
- When a non-existent instance of a component is requested in the browser passing a renderer the request hangs and responds with an error `503`.

**Issue reference:**
- https://github.com/clay/amphora/issues/617