### PR TITLE
Google+ Deprecation Support

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -221,7 +221,8 @@ function createGoogleStrategy(site) {
     clientID: process.env.GOOGLE_CONSUMER_KEY,
     clientSecret: process.env.GOOGLE_CONSUMER_SECRET,
     callbackURL: getCallbackUrl(site, 'google'),
-    passReqToCallback: true
+    passReqToCallback: true,
+    userProfileURL: process.env.GOOGLE_PROFILE_URL
   },
   verify({
     username: 'emails[0].value',


### PR DESCRIPTION
Solution pulled from: https://github.com/jaredhanson/passport-google-oauth2/pull/51

To use the new authentication API set `GOOGLE_PROFILE_URL` to `https://www.googleapis.com/oauth2/v3/userinfo`

