### PR TITLE
prefer url

### DIFF
--- a/lib/services/publish.js
+++ b/lib/services/publish.js
@@ -86,7 +86,7 @@ function _checkForUrlProperty(uri, { url, customUrl }) {
     return bluebird.reject(new Error('Page does not have a `url` or `customUrl` property set'));
   }
 
-  return bluebird.resolve(customUrl || url);
+  return bluebird.resolve(url || customUrl);
 }
 
 /**


### PR DESCRIPTION
When moving to Amphora v7 we began the deprecation `customUrl` in favor of `url` but the internal preference of the publish rule never changed. This is a bug we need to resolve to deprecate that property.