### PR TITLE
One More CustomUrl Assumption

### DIFF
--- a/lib/services/publish.js
+++ b/lib/services/publish.js
@@ -137,8 +137,6 @@ function addToMeta(meta, modifiers = [], uri, data) {
  * @return {Promise}
  */
 function publishPageAtUrl(url, uri, data, locals, site) { // eslint-disable-line
-  // So a url can still be derived from rules unique to the
-  // implementation, but customUrl should override those rules
   if (data._dynamic) {
     locals.isDynamicPublishUrl = true;
     return data;

--- a/lib/services/publish.js
+++ b/lib/services/publish.js
@@ -139,8 +139,6 @@ function addToMeta(meta, modifiers = [], uri, data) {
 function publishPageAtUrl(url, uri, data, locals, site) { // eslint-disable-line
   // So a url can still be derived from rules unique to the
   // implementation, but customUrl should override those rules
-  url = data.customUrl || url;
-
   if (data._dynamic) {
     locals.isDynamicPublishUrl = true;
     return data;


### PR DESCRIPTION
This function handles plucking the url set to a page from either `customUrl` or `url`: https://github.com/clay/amphora/blob/master/lib/services/publish.js#L231

It does this because a built in publish rule does the check: https://github.com/clay/amphora/blob/master/lib/services/publish.js#L84-L90

So by the time we reach the point to actually publish the page we don't need to check for the `customUrl` property: https://github.com/clay/amphora/blob/master/lib/services/publish.js#L142


