### PR TITLE
Add declaration of db module methods

### DIFF
--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -126,5 +126,16 @@ module.exports.getLatestData = getLatestData;
 module.exports.pipeToPromise = pipeToPromise;
 module.exports.registerStorage = registerStorage;
 
+// methods from storage module, assigned in registerStorage
+module.exports.put;
+module.exports.get;
+module.exports.del;
+module.exports.batch;
+module.exports.putMeta;
+module.exports.patchMeta;
+module.exports.getMeta;
+module.exports.raw;
+module.exports.createReadStream;
+
 // For testing
 module.exports.defer = defer;


### PR DESCRIPTION
This addition is simply to aid users who are looking for the initialization of the db methods that are used throughout amphora. Users can search for these methods in the /services/db.js file, which makes the connection do a db module easier to trace and to understand.