### PR TITLE
Plugin whitelist

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -65,7 +65,7 @@ function withAuthLevel(requiredLevel) {
  * @param {object} req
  * @returns {boolean}
  */
-function isProtectedRoute({ query, skipAuth, method }) {
+function isProtectedRoute({ query, skipAuth = false, method }) {
   return !!query.edit || skipAuth === false && method !== 'GET';
 }
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -65,8 +65,8 @@ function withAuthLevel(requiredLevel) {
  * @param {object} req
  * @returns {boolean}
  */
-function isProtectedRoute(req) {
-  return !!req.query.edit || req.method !== 'GET';
+function isProtectedRoute({ query, skipAuth, method }) {
+  return !!query.edit || skipAuth === false && method !== 'GET';
 }
 
 /**

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -223,7 +223,9 @@ function addSite(router, { providers, sessionStore }, site) {
   const path = site.path,
     siteRouter = express.Router();
 
-  // authentication added first to protect all routes
+  siteRouter.use(plugins.skipAuth);
+
+  // authentication added first to protect routes
   if (!_.isEmpty(providers)) {
     auth.init(siteRouter, providers, site, sessionStore);
   }

--- a/lib/services/plugins.js
+++ b/lib/services/plugins.js
@@ -4,7 +4,9 @@ const bluebird = require('bluebird'),
   db = require('../services/db'),
   sites = require('../services/sites'),
   { getMeta, patchMeta } = require('../services/metadata'),
-  { publish } = require('../services/bus');
+  { publish } = require('../services/bus'),
+  { removeQueryString } = require('../responses');
+
 var log = require('./logger').setup({
     file: __filename
   }),
@@ -24,8 +26,10 @@ function initPlugins(router) {
     return bluebird.try(() => {
       if (typeof plugin === 'function') {
         return plugin(router, pluginDBAdapter, publish, sites);
+      } else if (typeof plugin.init === 'function') {
+        return plugin.init(router, pluginDBAdapter, publish, sites);
       } else {
-        log('warn', 'Plugin is not a function');
+        log('warn', 'Plugin should be a function or have an init function');
         return bluebird.resolve();
       }
     });
@@ -62,14 +66,31 @@ function createDBAdapter() {
  * @param  {Array} plugins [description]]
  */
 function registerPlugins(plugins) {
+  module.exports.whitelist = getFullWhitelist(plugins);
+
   // Need to wrap the DB methods in automatic publish to bus
   pluginDBAdapter = createDBAdapter();
   module.exports.plugins = plugins;
 }
 
+function getFullWhitelist(plugins) {
+  return plugins.reduce((output, plugin) => {
+    return typeof plugin !== 'function' && plugin.whitelist && plugin.whitelist.length
+      ? output.concat(plugin.whitelist)
+      : output;
+  }, []);
+}
+
+function skipAuth(req, res, next) {
+  // Memoize this
+  req.skipAuth = module.exports.whitelist.includes(removeQueryString(req.url));
+  next();
+}
+
 module.exports.plugins = [];
 module.exports.registerPlugins = registerPlugins;
 module.exports.initPlugins = initPlugins;
+module.exports.skipAuth = skipAuth;
 
 // For testing
 module.exports.setLog = mock => log = mock;

--- a/lib/services/plugins.js
+++ b/lib/services/plugins.js
@@ -29,7 +29,7 @@ function initPlugins(router) {
       } else if (typeof plugin.init === 'function') {
         return plugin.init(router, pluginDBAdapter, publish, sites);
       } else {
-        log('warn', 'Plugin should be a function or have an init function');
+        log('warn', 'Plugin is not a function or does not have an init function');
         return bluebird.resolve();
       }
     });
@@ -66,14 +66,14 @@ function createDBAdapter() {
  * @param  {Array} plugins [description]]
  */
 function registerPlugins(plugins) {
-  module.exports.whitelist = getFullWhitelist(plugins);
+  module.exports.whitelist = getWhitelistFromPlugins(plugins);
 
   // Need to wrap the DB methods in automatic publish to bus
   pluginDBAdapter = createDBAdapter();
   module.exports.plugins = plugins;
 }
 
-function getFullWhitelist(plugins) {
+function getWhitelistFromPlugins(plugins) {
   return plugins.reduce((output, plugin) => {
     return typeof plugin !== 'function' && plugin.whitelist && plugin.whitelist.length
       ? output.concat(plugin.whitelist)
@@ -82,12 +82,12 @@ function getFullWhitelist(plugins) {
 }
 
 function skipAuth(req, res, next) {
-  // Memoize this
   req.skipAuth = module.exports.whitelist.includes(removeQueryString(req.url));
   next();
 }
 
 module.exports.plugins = [];
+module.exports.whitelist = [];
 module.exports.registerPlugins = registerPlugins;
 module.exports.initPlugins = initPlugins;
 module.exports.skipAuth = skipAuth;

--- a/lib/services/plugins.js
+++ b/lib/services/plugins.js
@@ -85,7 +85,7 @@ function getWhitelistFromPlugins(plugins) {
 function skipAuth(req, res, next) {
   const url = removeQueryString(req.url);
 
-  req.skipAuth = _memoize(module.exports.whitelist.includes)(url);
+  req.skipAuth = module.exports.whitelist.includes(url);
   next();
 }
 
@@ -94,6 +94,7 @@ module.exports.whitelist = [];
 module.exports.registerPlugins = registerPlugins;
 module.exports.initPlugins = initPlugins;
 module.exports.skipAuth = skipAuth;
+module.exports.getWhitelistFromPlugins = getWhitelistFromPlugins;
 
 // For testing
 module.exports.setLog = mock => log = mock;

--- a/lib/services/plugins.js
+++ b/lib/services/plugins.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const bluebird = require('bluebird'),
+  _memoize = require('lodash/memoize'),
   db = require('../services/db'),
   sites = require('../services/sites'),
   { getMeta, patchMeta } = require('../services/metadata'),
@@ -82,7 +83,9 @@ function getWhitelistFromPlugins(plugins) {
 }
 
 function skipAuth(req, res, next) {
-  req.skipAuth = module.exports.whitelist.includes(removeQueryString(req.url));
+  const url = removeQueryString(req.url);
+
+  req.skipAuth = _memoize(module.exports.whitelist.includes)(url);
   next();
 }
 

--- a/lib/services/plugins.js
+++ b/lib/services/plugins.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const bluebird = require('bluebird'),
-  _memoize = require('lodash/memoize'),
   db = require('../services/db'),
   sites = require('../services/sites'),
   { getMeta, patchMeta } = require('../services/metadata'),
@@ -74,6 +73,13 @@ function registerPlugins(plugins) {
   module.exports.plugins = plugins;
 }
 
+/**
+ * Gets the whitelist of each plugin
+ * and merges them into a single array.
+ *
+ * @param {Object[]} plugins
+ * @returns {string[]}
+ */
 function getWhitelistFromPlugins(plugins) {
   return plugins.reduce((output, plugin) => {
     return typeof plugin !== 'function' && plugin.whitelist && plugin.whitelist.length
@@ -82,6 +88,13 @@ function getWhitelistFromPlugins(plugins) {
   }, []);
 }
 
+/**
+ * Skips authentication if the request url is in the whitelist.
+ *
+ * @param {Object} req
+ * @param {Object} res
+ * @param {Function} next
+ */
 function skipAuth(req, res, next) {
   const url = removeQueryString(req.url);
 

--- a/lib/services/plugins.test.js
+++ b/lib/services/plugins.test.js
@@ -11,12 +11,13 @@ const _ = require('lodash'),
   expect = require('chai').expect;
 
 describe(_.startCase(filename), function () {
-  let sandbox, plugin, fakeLog;
+  let sandbox, plugin, pluginWithMetadata, fakeLog;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
 
     plugin = sandbox.stub();
+    pluginWithMetadata = { init: sandbox.stub().returns(true) };
     fakeLog = sandbox.stub();
     lib.setLog(fakeLog);
     sandbox.stub(composer, 'resolveComponentReferences');
@@ -43,12 +44,13 @@ describe(_.startCase(filename), function () {
     const fn = lib[this.title];
 
     it('will try to invoke each plugin', function () {
-      lib.plugins = [plugin];
+      lib.plugins = [plugin, pluginWithMetadata];
       plugin.returns(true);
 
       return fn()
         .then(() => {
           sinon.assert.calledOnce(plugin);
+          sinon.assert.calledOnce(pluginWithMetadata.init);
         });
     });
 
@@ -60,6 +62,41 @@ describe(_.startCase(filename), function () {
         .then(() => {
           sinon.assert.calledWith(fakeLog, 'warn', 'Plugin is not a function or does not have an init function');
         });
+    });
+  });
+
+  describe('getWhitelistFromPlugins', function () {
+    it('returns an array of all the plugin\'s whitelist combined', function () {
+      const plugins = [plugin, pluginWithMetadata];
+
+      pluginWithMetadata.whitelist = ['/_test'];
+      plugin.returns(true);
+
+      expect(lib.getWhitelistFromPlugins(plugins)).to.eql(['/_test']);
+    });
+
+    it('returns an empty array if no plugins have a whitelist', function () {
+      const plugins = [plugin,];
+
+      plugin.returns(true);
+      lib.getWhitelistFromPlugins(plugins);
+
+      expect(lib.getWhitelistFromPlugins(plugins)).to.be.empty;
+    });
+  });
+
+  describe('skipAuth', function () {
+    it('sets skipAuth to true if the request url is in the whitelist', function () {
+      const req = { headers: {}, url: '/_test' };
+
+      lib.whitelist = ['/_test'];
+      lib.skipAuth(req, {}, sandbox.stub());
+
+      expect(req.skipAuth).to.be.true;
+    });
+
+    it('calls next', function (done) {
+      lib.skipAuth({ url: '' }, {}, done);
     });
   });
 });

--- a/lib/services/plugins.test.js
+++ b/lib/services/plugins.test.js
@@ -52,13 +52,13 @@ describe(_.startCase(filename), function () {
         });
     });
 
-    it('logs a warning if a plugin is not a function', function () {
+    it('logs a warning if a plugin is not a function or does not have an init function', function () {
       lib.plugins = [false];
       plugin.returns(true);
 
       return fn()
         .then(() => {
-          sinon.assert.calledWith(fakeLog, 'warn', 'Plugin is not a function');
+          sinon.assert.calledWith(fakeLog, 'warn', 'Plugin is not a function or does not have an init function');
         });
     });
   });

--- a/lib/services/plugins.test.js
+++ b/lib/services/plugins.test.js
@@ -76,7 +76,7 @@ describe(_.startCase(filename), function () {
     });
 
     it('returns an empty array if no plugins have a whitelist', function () {
-      const plugins = [plugin,];
+      const plugins = [plugin];
 
       plugin.returns(true);
       lib.getWhitelistFromPlugins(plugins);


### PR DESCRIPTION
# Whitelist to skip plugin auth

Plugins can also be objects now so they can pass metadata to amphora like a routes whitelist.

```js
...
plugins: [
  ...,
  amphoraSearchPlugin,
  { init: testPluginFunction, whitelist: ['/_test-route'] };
],
...
```
This allows amphora to know which routes should skip the authentication

## TODO
- [ ] Update [plugins documentation](https://github.com/clay/amphora/blob/9443c88ae5659c0d1693172db9d80d8b0eace477/docs/basics/plugins.md)
- [ ] Memoization of the route check

Closes #640 