### PR TITLE
Add plugin documentation

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -1,0 +1,46 @@
+---
+id: plugin
+title: Plugins
+sidebar_label: Plugins
+---
+
+Plugins allow you to extend the functionality of your site by allowing you to attach routes to each site's router in your instance. While this may not seem any different than [defining routes for your site](routes), the basic site router will assign routes that only respond to `GET` requests and will run through Amphora's composition/rendering functionality. Plugins allow you to assign routes that respond to any [Express supported request method](https://expressjs.com/en/4x/api.html#app.METHOD) with your own custom handlers.
+
+## Anatomy of a Plugin
+
+A plugin should be a function and will receive the following arguments:
+
+- `router`: the router for the site. Attach listeners and handlers as you would to any Express router.
+- `db`: an instance of Amphora's internal database connector.
+- `bus`: a passthrough of Amphora's internal event bus publish method so that a plugin can publish to the event bus on its own.
+- `sites`: the internal `sites` service, used for discovering which site in your instance a URI belongs to.
+
+An example plugin might look like the following:
+
+```javascript
+module.exports = (router, db, bus, sites) => {
+  // Attach a route that responds to PUT requests
+  router.put('/_coolroute', (req, res) => {
+    return db.put(req.uri, req.body)
+      .then(() => {
+        // Pub to the event bus that the route was called
+        bus('coolRouteCalled', { body: req.body });
+        // Respond to the request
+        res.json({ status: 200 })
+      });
+  });
+
+  // Note: we're not explicitly returning anything, but if we were
+  // performing some async action we could return a Promise
+}
+```
+
+You aren't required to explicitly `return` any value from your plugin, but you can return a `Promise` if needed.
+
+## Lifecycle of Plugin
+
+A plugin is called...
+
+- once for every site in your Clay instance
+- _after_ the storage module is instantiated
+- _before_ bootstrapping happens

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -10,6 +10,7 @@
     "Basics": [
       "routes",
       "publish",
+      "plugin",
       {
         "type": "subcategory",
         "label": "Renderers",

--- a/website/versioned_docs/version-7.3.2/plugin.md
+++ b/website/versioned_docs/version-7.3.2/plugin.md
@@ -1,0 +1,47 @@
+---
+id: version-7.3.2-plugin
+title: Plugin
+sidebar_label: Plugin
+original_id: plugin
+---
+
+Plugins allow you to extend the functionality of your site by allowing you to attach routes to each site's router in your instance. While this may not seem any different than [defining routes for your site](routes), the basic site router will assign routes that only respond to `GET` requests and will run through Amphora's composition/rendering functionality. Plugins allow you to assign routes that respond to any [Express supported request method](https://expressjs.com/en/4x/api.html#app.METHOD) with your own custom handlers.
+
+## Anatomy of a Plugin
+
+A plugin should be a function and will receive the following arguments:
+
+- `router`: the router for the site. Attach listeners and handlers as you would to any Express router.
+- `db`: an instance of Amphora's internal database connector.
+- `bus`: a passthrough of Amphora's internal event bus publish method so that a plugin can publish to the event bus on its own.
+- `sites`: the internal `sites` service, used for discovering which site in your instance a URI belongs to.
+
+An example plugin might look like the following:
+
+```javascript
+module.exports = (router, db, bus, sites) => {
+  // Attach a route that responds to PUT requests
+  router.put('/_coolroute', (req, res) => {
+    return db.put(req.uri, req.body)
+      .then(() => {
+        // Pub to the event bus that the route was called
+        bus('coolRouteCalled', { body: req.body });
+        // Respond to the request
+        res.json({ status: 200 })
+      });
+  });
+
+  // Note: we're not explicitly returning anything, but if we were
+  // performing some async action we could return a Promise
+}
+```
+
+You aren't required to explicitly `return` any value from your plugin, but you can return a `Promise` if needed.
+
+## Lifecycle of Plugin
+
+A plugin is called...
+
+- once for every site in your Clay instance
+- _after_ the storage module is instantiated
+- _before_ bootstrapping happens

--- a/website/versioned_sidebars/version-7.3.2-sidebars.json
+++ b/website/versioned_sidebars/version-7.3.2-sidebars.json
@@ -11,6 +11,7 @@
     "Basics": [
       "version-7.3.2-routes",
       "version-7.3.2-publish",
+      "version-7.3.2-plugin",
       {
         "type": "subcategory",
         "label": "Renderers",


### PR DESCRIPTION
Adding plugin docs.

# Steps for testing the site locally:
- Go to the `website` folder
- Install all dependencies using `npm install`
- Start your local server using `npm run start`
- Test locally at [localhost master](http://localhost:3000/amphora/docs/next/plugin)
- Test locally at [localhost](http://localhost:3000/amphora/docs/plugin)