### PR TITLE
Pass site to each plugin

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -244,7 +244,7 @@ function addSite(router, { providers, sessionStore }, site) {
   siteRouter.use(addAvailableComponents);
 
   // Plugins can add routes to a site, fire that hook now to register those routes
-  return plugins.initPlugins(siteRouter)
+  return plugins.initPlugins(siteRouter, site)
     .then(() => {
       const siteControllerConfig = site.dir ? files.tryRequire(site.dir) : {},
         midleware = _.get(siteControllerConfig, 'middleware', null);

--- a/lib/services/plugins.js
+++ b/lib/services/plugins.js
@@ -17,13 +17,14 @@ var log = require('./logger').setup({
  * of the bus service.
  *
  * @param {Object} router
+ * @param {Object} site
  * @returns {Promise}
  */
-function initPlugins(router) {
+function initPlugins(router, site) {
   return bluebird.all(module.exports.plugins.map(plugin => {
     return bluebird.try(() => {
       if (typeof plugin === 'function') {
-        return plugin(router, pluginDBAdapter, publish, sites);
+        return plugin(router, pluginDBAdapter, publish, sites, site);
       } else {
         log('warn', 'Plugin is not a function');
         return bluebird.resolve();


### PR DESCRIPTION
In order for the static file serving plugin to work, amphora must pass the `site` object to each plugin. 
https://github.com/clay/clay/issues/17