### PR TITLE
Allow plugins to opt-in/out of authentication

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -200,6 +200,8 @@ function addSite(router, { providers, sessionStore }, site) {
       const siteControllerConfig = site.dir ? files.tryRequire(site.dir) : {},
         midleware = _.get(siteControllerConfig, 'middleware', null);
 
+      amphoraAuth.useAuth(siteRouter);
+
       if (Array.isArray(midleware)) {
         siteRouter.use(midleware);
       }
@@ -310,7 +312,7 @@ function loadFromConfig(router, providers, sessionStore) {
 
   // iterate through the hosts
   _.each(siteHosts, hostname => {
-    const sites = _.filter(sitesMap, {host: hostname}).sort(sortByDepthOfPath);
+    const sites = _.filter(sitesMap, { host: hostname }).sort(sortByDepthOfPath);
 
     addHost({
       router,

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -27,6 +27,7 @@ describe(_.startCase(filename), function () {
     fakeLog = sandbox.stub();
     fakeAuth = sandbox.stub();
     fakeAuth.addRoutes = sandbox.stub();
+    fakeAuth.useAuth = sandbox.stub();
 
     lib.setLog(fakeLog);
     lib.setamphoraAuth(fakeAuth);

--- a/lib/services/plugins.js
+++ b/lib/services/plugins.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const bluebird = require('bluebird'),
+  { useAuth } = require('amphora-auth'),
   db = require('../services/db'),
   sites = require('../services/sites'),
   { getMeta, patchMeta } = require('../services/metadata'),
@@ -24,7 +25,7 @@ function initPlugins(router, site) {
   return bluebird.all(module.exports.plugins.map(plugin => {
     return bluebird.try(() => {
       if (typeof plugin === 'function') {
-        return plugin(router, pluginDBAdapter, publish, sites, site);
+        return plugin(router, pluginDBAdapter, publish, sites, site, useAuth);
       } else {
         log('warn', 'Plugin is not a function');
         return bluebird.resolve();


### PR DESCRIPTION
## Feature Info

### Description

- Passes a function (`useAuth`) to each plugin.

### Plugin example

```js
const express = require('express');

module.exports = (router, _pluginDBAdapter, _publish, _sites, _site, useAuth) => {
  const pluginRouter = express.Router();

  useAuth(pluginRouter);
  pluginRouter.use((req, res) => res.json({ method: req.method }));
  router.use('/_test', pluginRouter);
}
```

### Related
https://github.com/clay/amphora-auth/pull/19