### PR TITLE
Updates patchMeta method to add archive events to history

### DIFF
--- a/lib/routes/_pages.js
+++ b/lib/routes/_pages.js
@@ -120,7 +120,7 @@ let route = _.bindAll({
    * @param  {Object} res
    */
   patchMeta(req, res) {
-    responses.expectJSON(() => metaController.patchMeta(req.uri, req.body), res);
+    responses.expectJSON(() => metaController.patchMeta(req.uri, req.body, res.locals), res);
   }
 }, [
   'post',

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -224,12 +224,27 @@ function putMeta(uri, data) {
  *
  * @param {String} uri
  * @param {Object} data
+ * @param {Object} locals
  * @returns {Promise}
  */
-function patchMeta(uri, data) {
-  const id = replaceVersion(uri.replace('/meta', ''));
+function patchMeta(uri = '', data = {}, locals = {}) {
+  const id = replaceVersion(uri.replace('/meta', '')),
+    update = {
+      updateTime: data.updateTime,
+      history: data.history,
+      archived: data.archived,
+      users: data.users
+    };
 
-  return db.patchMeta(id, data)
+  if (data.shouldPatchArchive) {
+    const { user } = locals,
+      action = update.archived ? 'archive' : 'unarchive',
+      historyEntry = { action, timestamp: new Date().toISOString(), users: [userOrRobot(user)] };
+
+    update.history.push(historyEntry);
+  }
+
+  return db.patchMeta(id, update)
     .then(() => getMeta(uri))
     .then(pubToBus(id));
 }

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -230,18 +230,25 @@ function putMeta(uri, data) {
 function patchMeta(uri = '', data = {}, locals = {}) {
   const id = replaceVersion(uri.replace('/meta', ''));
 
-  if (data.shouldPatchArchive) {
-    const { user } = locals,
-      action = data.archived ? 'archive' : 'unarchive',
-      historyEntry = { action, timestamp: new Date().toISOString(), users: [userOrRobot(user)] };
-
-    data.history.push(historyEntry);
-    delete data.shouldPatchArchive;
-  }
+  if (data.shouldPatchArchive) addArchiveEvent(data, locals.user);
 
   return db.patchMeta(id, data)
     .then(() => getMeta(uri))
     .then(pubToBus(id));
+}
+
+/**
+ * Adds the archive events to the metadata history.
+ * @param {Object} data
+ * @param {Object} user
+ * @returns {void}
+ */
+function addArchiveEvent(data, user = {}) {
+  const action = data.archived ? 'archive' : 'unarchive',
+    historyEntry = { action, timestamp: new Date().toISOString(), users: [userOrRobot(user)] };
+
+  data.history.push(historyEntry);
+  delete data.shouldPatchArchive;
 }
 
 /**

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -228,23 +228,18 @@ function putMeta(uri, data) {
  * @returns {Promise}
  */
 function patchMeta(uri = '', data = {}, locals = {}) {
-  const id = replaceVersion(uri.replace('/meta', '')),
-    update = {
-      updateTime: data.updateTime,
-      history: data.history,
-      archived: data.archived,
-      users: data.users
-    };
+  const id = replaceVersion(uri.replace('/meta', ''));
 
   if (data.shouldPatchArchive) {
     const { user } = locals,
-      action = update.archived ? 'archive' : 'unarchive',
+      action = data.archived ? 'archive' : 'unarchive',
       historyEntry = { action, timestamp: new Date().toISOString(), users: [userOrRobot(user)] };
 
-    update.history.push(historyEntry);
+    data.history.push(historyEntry);
+    delete data.shouldPatchArchive;
   }
 
-  return db.patchMeta(id, update)
+  return db.patchMeta(id, data)
     .then(() => getMeta(uri))
     .then(pubToBus(id));
 }

--- a/lib/services/metadata.test.js
+++ b/lib/services/metadata.test.js
@@ -69,11 +69,51 @@ describe(_.startCase(filename), function () {
       db.patchMeta.returns(Promise.resolve());
       db.getMeta.returns(Promise.resolve());
 
-      return fn('domain.com/_pages/id/meta', {})
+      return fn('domain.com/_pages/id/meta', {}, {})
         .then(() => {
           sinon.assert.calledWith(db.patchMeta, 'domain.com/_pages/id', {});
           sinon.assert.calledWith(db.getMeta, 'domain.com/_pages/id');
           sinon.assert.calledOnce(bus.publish);
+        });
+    });
+
+    it('adds archive event to history if specified', function () {
+      const data = {
+        history: [],
+        archived: true,
+        shouldPatchArchive: true
+      };
+
+      db.patchMeta.returns(Promise.resolve());
+      db.getMeta.returns(Promise.resolve());
+
+      return fn('domain.com/_pages/id/meta', data, {})
+        .then(() => {
+          const item = data.history[0];
+
+          expect(data.history).length(1);
+          expect(data.shouldPatchArchive).to.be.undefined;
+          expect(item.action).to.equal('archive');
+        });
+    });
+
+    it('adds unarchive event to history if specified', function () {
+      const data = {
+        history: [],
+        archived: false,
+        shouldPatchArchive: true
+      };
+
+      db.patchMeta.returns(Promise.resolve());
+      db.getMeta.returns(Promise.resolve());
+
+      return fn('domain.com/_pages/id/meta', data, {})
+        .then(() => {
+          const item = data.history[0];
+
+          expect(data.history).length(1);
+          expect(data.shouldPatchArchive).to.be.undefined;
+          expect(item.action).to.equal('unarchive');
         });
     });
   });


### PR DESCRIPTION
### Description

* Modifies `patchMeta` method in metadata controller in order to be able to know when to add archive events in the metadata history
* This closes issue #633 

### QA

* Do `npm link` to `clay-kiln` in branch `update-archive`
* Archive/Unarchive any article
* Go to page metadata in `<page_uri>/meta`
* Events should be logged inside `history` array