### PR TITLE
[Block]Add search config for the docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -53,7 +53,12 @@ const siteConfig = {
 
   // Open Graph and Twitter card images.
   ogImage: '',
-  twitterImage: ''
+  twitterImage: '',
+  algolia: {
+    apiKey: process.env.ALGOLIA_API_KEY,
+    indexName: 'TBD',
+    algoliaOptions: {} // Optional, if provided by Algolia
+  }
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Add search config for the docs

# Steps for testing the site locally:
- Go to the `website` folder
- Install package using `npm install`
- Start your local server using `npm start`
- Go to [localhost](http://localhost:3000/amphora/)
- Check on the top rigth corner of the page and will be a search input
- Compare with the current [docs page](https://docs.clayplatform.com/amphora/)

## Intallation process:
https://docusaurus.io/docs/en/search

## Official Algolia site
https://community.algolia.com/docsearch/

Note:
- We need the `Angolia` api key to create the secret and the `indexName`