### PR TITLE
User's data normalization

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -9,8 +9,8 @@ const path = require('path'),
   dbOps = require('./services/db-operations'),
   siteService = require('./services/sites'),
   references = require('./services/references'),
+  { createUserUri } = require('./services/metadata'),
   highland = require('highland'),
-  { encode } = require('./services/buffer'),
   locals = require('./locals');
 var log = require('./services/logger').setup({
     file: __filename,
@@ -221,7 +221,7 @@ function load(data, site) {
     ).then(_.flatten);
   });
   promisePagesOps = saveObjects(`${prefix}/_pages/`, compData._pages, (name, item) => [getPutOperation(name, item)]);
-  promiseUsersOps = saveObjects('', compData._users, (name, item) => [getPutOperation(`/_users/${encode(`${item.username}@${item.provider}`)}`, item)]);
+  promiseUsersOps = saveObjects('', compData._users, (name, item) => [getPutOperation(`/_users/${createUserUri(item)}`, item)]);
 
   /* eslint max-params: ["error", 5] */
   return bluebird.join(promiseComponentsOps, promisePagesOps, promiseUrisOps, promiseListsOps, promiseUsersOps, function (componentsOps, pagesOps, urisOps, listsOps, userOps) {

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -2,9 +2,22 @@
 
 const _ = require('lodash'),
   bus = require('./bus'),
+  { encode } = require('./buffer'),
   { replaceVersion } = require('clayutils'),
   sitesService = require('./sites');
 var db = require('./db');
+
+/**
+ * Creates the id for a user
+ *
+ * @param {Object} user
+ * @param {string} user.username
+ * @param {string} user.provider
+ * @returns {string}
+ */
+function createUserUri({ username = '', provider = '' }) {
+  return encode(`${username}@${provider}`);
+}
 
 /**
  * Either return the user object or
@@ -14,18 +27,19 @@ var db = require('./db');
  * @returns {Object}
  */
 function userOrRobot(user) {
-  if (user && _.get(user, 'username') && _.get(user, 'provider')) {
-    return user;
-  } else {
-    // no actual user, this was an api key
-    return {
-      username: 'robot',
-      provider: 'clay',
-      imageUrl: 'clay-avatar', // kiln will supply a clay avatar
-      name: 'Clay',
-      auth: 'admin'
-    };
-  }
+  const output = user && _.get(user, 'username') && _.get(user, 'provider')
+    ? user
+    : { username: 'robot', provider: 'clay' };
+
+  return createUserUri(output);
+  // TODO: Save the following data in `/_users/${btoa('robot@clay')}`
+  // return {
+  //   username: 'robot',
+  //   provider: 'clay',
+  //   imageUrl: 'clay-avatar', // kiln will supply a clay avatar
+  //   name: 'Clay',
+  //   auth: 'admin'
+  // };
 }
 
 /**
@@ -71,7 +85,7 @@ function createPage(ref, user) {
       title: '',
       authors: [],
       users,
-      history: [{action: 'create', timestamp: NOW, users }],
+      history: [{ action: 'create', timestamp: NOW, users }],
       siteSlug: sitesService.getSiteFromPrefix(ref.substring(0, ref.indexOf('/_pages'))).slug
     };
 
@@ -283,6 +297,7 @@ module.exports.publishLayout = publishLayout;
 module.exports.unpublishPage = unpublishPage;
 module.exports.userOrRobot = userOrRobot;
 module.exports.checkProps = checkProps;
+module.exports.createUserUri = createUserUri;
 
 // For testing
 module.exports.setDb = mock => db = mock;

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -27,19 +27,15 @@ function createUserUri({ username = '', provider = '' }) {
  * @returns {Object}
  */
 function userOrRobot(user) {
-  const output = user && _.get(user, 'username') && _.get(user, 'provider')
+  const { username, provider } = user && _.get(user, 'username') && _.get(user, 'provider')
     ? user
     : { username: 'robot', provider: 'clay' };
 
-  return createUserUri(output);
-  // TODO: Save the following data in `/_users/${btoa('robot@clay')}`
-  // return {
-  //   username: 'robot',
-  //   provider: 'clay',
-  //   imageUrl: 'clay-avatar', // kiln will supply a clay avatar
-  //   name: 'Clay',
-  //   auth: 'admin'
-  // };
+  return {
+    id: createUserUri({ username, provider }),
+    username,
+    provider
+  };
 }
 
 /**

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -296,4 +296,5 @@ module.exports.checkProps = checkProps;
 module.exports.createUserUri = createUserUri;
 
 // For testing
+module.exports.userOrRobot = userOrRobot;
 module.exports.setDb = mock => db = mock;

--- a/lib/services/metadata.test.js
+++ b/lib/services/metadata.test.js
@@ -257,6 +257,25 @@ describe(_.startCase(filename), function () {
           expect(resp).to.eql(errMsg);
         });
     });
+  });
 
+  describe('userOrRobot', function () {
+    const fn = lib[this.title];
+
+    it('should return the user object', function () {
+      const username = 'pizza@everyday',
+        provider = 'doesntmatter',
+        userOrRobot = fn({ username, provider }),
+        expectedValue = { id: 'cGl6emFAZXZlcnlkYXlAZG9lc250bWF0dGVy', username, provider };
+
+      expect(userOrRobot).to.eql(expectedValue);
+    });
+
+    it('should return the system user (robot) object', function () {
+      const userOrRobot = fn(),
+        expectedValue = { id: 'cm9ib3RAY2xheQ==', username: 'robot', provider: 'clay' };
+
+      expect(userOrRobot).to.eql(expectedValue);
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2182,7 +2182,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },


### PR DESCRIPTION
Solving an issue where the users data in the meta of the page and the `_users` endpoint wasn't synced.

We'll only handle the properties that shouldn't change and request for the changeable information (like the name or picture) everytime we need. 

This is going to work in conjunction with a clay-kiln, amphora-auth and amphora-search change