### PR TITLE
Subsite support

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -297,6 +297,8 @@ function bootstrapSite(site) {
     .then(function () {
       if (site.subsite) {
         return bootstrapPath(site.dir, site);
+      } else {
+        return site;
       }
     })
     .catch(function () {

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -283,11 +283,12 @@ function bootstrapError(component, e) {
 /**
  * Bootstraps a site, and if it fails, falls back to the parent sites' bootstrap (for subsites)
  *
- * @param {Object} site 
+ * @param {Object} site
+ * @return {Promise}
  */
 function bootstrapSite(site) {
   return bootstrapPath(site.dir, site)
-    .catch(function(e) {
+    .catch(function (e) {
       if (site.subsite) {
         log('info', `No bootstrap file found for site: ${site.slug} at ${site.dir} so checking for parent site.`);
         const parent = siteService.getParentSite(site.slug);

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -292,17 +292,11 @@ function bootstrapSite(site) {
 
   // using module.exports for test
   return module.exports.bootstrapPath(parent.dir, site)
-    .catch(function () {
+    .catch(() => {
       log('debug', `No bootstrap file found for parent site: ${site.slug}`);
     })
-    .then(function () {
-      if (site.subsite) {
-        return module.exports.bootstrapPath(site.dir, site);
-      } else {
-        return site;
-      }
-    })
-    .catch(function () {
+    .then(() => site.subsite ? module.exports.bootstrapPath(site.dir, site) : site)
+    .catch(() => {
       log('debug', `No bootstrap file found for subsite: ${site.slug} ${site.subsite}`);
       return site;
     });

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -281,6 +281,25 @@ function bootstrapError(component, e) {
 }
 
 /**
+ * Bootstraps a site, and if it fails, falls back to the parent sites' bootstrap (for subsites)
+ *
+ * @param {Object} site 
+ */
+function bootstrapSite(site) {
+  return bootstrapPath(site.dir, site)
+    .catch(function(e) {
+      if (site.subsite) {
+        log('info', `No bootstrap file found for site: ${site.slug} at ${site.dir} so checking for parent site.`);
+        const parent = siteService.getParentSite(site.slug);
+
+        return bootstrapPath(parent.dir, site);
+      } else {
+        throw e;
+      }
+    });
+}
+
+/**
  * Bootstrap all sites and the individual
  * bootstrap files in each component's directory
  *
@@ -305,7 +324,7 @@ function bootrapSitesAndComponents() {
     })
     .flatMap(site => {
       return highland(
-        bootstrapPath(site.dir, site)
+        bootstrapSite(site)
           .catch(function () {
             log('debug', `No bootstrap file found for site: ${site.slug}`);
             return site;

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -288,7 +288,7 @@ function bootstrapError(component, e) {
  */
 function bootstrapSite(site) {
   // fetches itself if it is the main site
-  const parent = siteService.getParentSite(site.slug);
+  const parent = siteService.getParentSite(site.slug) || site;
 
   // using module.exports for test
   return module.exports.bootstrapPath(parent.dir, site)

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -287,16 +287,20 @@ function bootstrapError(component, e) {
  * @return {Promise}
  */
 function bootstrapSite(site) {
-  return bootstrapPath(site.dir, site)
-    .catch(function (e) {
+  // fetches itself if it is the main site
+  const parent = siteService.getParentSite(site.slug);
+  return bootstrapPath(parent.dir, site)
+    .catch(function () {
+      log('debug', `No bootstrap file found for parent site: ${site.slug}`);
+    })
+    .then(function () {
       if (site.subsite) {
-        log('info', `No bootstrap file found for site: ${site.slug} at ${site.dir} so checking for parent site.`);
-        const parent = siteService.getParentSite(site.slug);
-
-        return bootstrapPath(parent.dir, site);
-      } else {
-        throw e;
+        return bootstrapPath(site.dir, site);
       }
+    })
+    .catch(function () {
+      log('debug', `No bootstrap file found for subsite: ${site.slug} ${site.subsite}`);
+      return site;
     });
 }
 
@@ -326,10 +330,6 @@ function bootrapSitesAndComponents() {
     .flatMap(site => {
       return highland(
         bootstrapSite(site)
-          .catch(function () {
-            log('debug', `No bootstrap file found for site: ${site.slug}`);
-            return site;
-          })
       );
     })
     .collect()

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -289,6 +289,7 @@ function bootstrapError(component, e) {
 function bootstrapSite(site) {
   // fetches itself if it is the main site
   const parent = siteService.getParentSite(site.slug);
+
   return bootstrapPath(parent.dir, site)
     .catch(function () {
       log('debug', `No bootstrap file found for parent site: ${site.slug}`);

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -290,13 +290,14 @@ function bootstrapSite(site) {
   // fetches itself if it is the main site
   const parent = siteService.getParentSite(site.slug);
 
-  return bootstrapPath(parent.dir, site)
+  // using module.exports for test
+  return module.exports.bootstrapPath(parent.dir, site)
     .catch(function () {
       log('debug', `No bootstrap file found for parent site: ${site.slug}`);
     })
     .then(function () {
       if (site.subsite) {
-        return bootstrapPath(site.dir, site);
+        return module.exports.bootstrapPath(site.dir, site);
       } else {
         return site;
       }
@@ -361,3 +362,4 @@ module.exports.bootstrapPath = bootstrapPath;
 // For testing
 module.exports.setLog = mock => log = mock;
 module.exports.setDb = mock => db = mock;
+module.exports.bootstrapSite = bootstrapSite;

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -288,7 +288,7 @@ function bootstrapError(component, e) {
  */
 function bootstrapSite(site) {
   // fetches itself if it is the main site
-  const parent = siteService.getParentSite(site.slug) || site;
+  const parent = siteService.getParentSite(site.slug);
 
   // using module.exports for test
   return module.exports.bootstrapPath(parent.dir, site)

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -22,7 +22,8 @@ describe(_.startCase(filename), function () {
     sitesFake = [{
       host: 'example1.com',
       dir: 'example1',
-      prefix: 'example1.com'
+      prefix: 'example1.com',
+      slug: 'a'
     }, {
       host: 'example2.com',
       path: '/',
@@ -103,6 +104,14 @@ describe(_.startCase(filename), function () {
 
   describe('bootstrapSite', function () {
     const fn = lib[this.title];
+
+    it('catches and logs if missing bootstrap', function () {
+      siteService.getParentSite.returns(_.cloneDeep(sitesFake[0]));
+      sandbox.stub(lib, 'bootstrapPath').returns(Promise.reject());
+      return fn(_.cloneDeep(sitesFake[0])).catch(() => {
+        sinon.assert.calledWith(fakeLog,'debug', 'No bootstrap file found for parent site: a');
+      });
+    });
 
     it('if no subsites, bootstrapPath runs once', function () {
       siteService.getParentSite.returns(_.cloneDeep(sitesFake[0]));

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -101,7 +101,7 @@ describe(_.startCase(filename), function () {
     });
   });
 
-  describe('bootstrapSite', function() {
+  describe('bootstrapSite', function () {
     const fn = lib[this.title];
 
     it('if no subsites, bootstrapPath runs once', function () {
@@ -113,7 +113,7 @@ describe(_.startCase(filename), function () {
       });
     });
 
-    it('if subsite, bootstrapPath runs twice', function() {
+    it('if subsite, bootstrapPath runs twice', function () {
       siteService.getParentSite.returns(_.cloneDeep(sitesFake[3]));
       sandbox.stub(lib, 'bootstrapPath').returns(Promise.resolve({}));
 

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -108,7 +108,7 @@ describe(_.startCase(filename), function () {
     it('catches and logs if missing bootstrap', function () {
       siteService.getParentSite.returns(_.cloneDeep(sitesFake[0]));
       sandbox.stub(lib, 'bootstrapPath').returns(Promise.reject());
-      return fn(_.cloneDeep(sitesFake[0])).catch(() => {
+      return fn(_.cloneDeep(sitesFake[0])).then(() => {
         sinon.assert.calledWith(fakeLog,'debug', 'No bootstrap file found for parent site: a');
       });
     });

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -33,6 +33,12 @@ describe(_.startCase(filename), function () {
       path: '/some-path',
       dir: 'example3',
       prefix: 'example1.com/some-path'
+    }, {
+      host: 'example4.com',
+      path: '/',
+      dir: 'example4',
+      prefix: 'example4.com',
+      subsite: 'example4'
     }];
 
     bootstrapFake = files.getYaml(path.resolve('./test/fixtures/config/bootstrap'));
@@ -75,7 +81,7 @@ describe(_.startCase(filename), function () {
     it('bootstraps', function () {
       files.getComponents.returns(['a', 'b', 'c']);
       files.getYaml.withArgs('example1').returns({});
-
+      siteService.getParentSite.returns(_.cloneDeep(sitesFake[0]));
       return fn();
     });
 
@@ -83,6 +89,7 @@ describe(_.startCase(filename), function () {
       files.getComponents.returns(['a', 'b', 'c']);
       files.getYaml.withArgs('example1').returns({});
       sandbox.stub(lib, 'bootstrapPath').returns(Promise.resolve({}));
+      siteService.getParentSite.returns(_.cloneDeep(sitesFake[0]));
       return fn();
     });
 
@@ -92,6 +99,29 @@ describe(_.startCase(filename), function () {
           sinon.assert.calledWith(fakeLog,'info', 'Skipping bootstrapping sites and components');
         });
     });
+  });
+
+  describe('bootstrapSite', function() {
+    const fn = lib[this.title];
+
+    it('if no subsites, bootstrapPath runs once', function () {
+      siteService.getParentSite.returns(_.cloneDeep(sitesFake[0]));
+      sandbox.stub(lib, 'bootstrapPath').returns(Promise.resolve({}));
+
+      return fn(_.cloneDeep(sitesFake[0])).then(() => {
+        sinon.assert.calledOnce(lib.bootstrapPath);
+      });
+    });
+
+    it('if subsite, bootstrapPath runs twice', function() {
+      siteService.getParentSite.returns(_.cloneDeep(sitesFake[3]));
+      sandbox.stub(lib, 'bootstrapPath').returns(Promise.resolve({}));
+
+      return fn(_.cloneDeep(sitesFake[3])).then(() => {
+        sinon.assert.calledTwice(lib.bootstrapPath);
+      });
+    });
+
   });
 
   describe('bootstrapPath', function () {

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -130,7 +130,6 @@ describe(_.startCase(filename), function () {
         sinon.assert.calledTwice(lib.bootstrapPath);
       });
     });
-
   });
 
   describe('bootstrapPath', function () {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -129,8 +129,18 @@ function addCORS(site) {
  * @returns {express.Router}
  */
 function addSiteController(router, site, providers) {
-  if (site.dir) {
-    const controller = files.tryRequire(site.dir);
+  // fetches itself if it is the main site
+  const parent = siteService.getParentSite(site.slug);
+
+  if (parent.dir) {
+    const controller = files.tryRequire(parent.dir);
+
+    // merge in subsiteController options
+    if (site.subsite) {
+      const subsiteController = files.tryRequire(site.dir);
+
+      _.merge(controller, subsiteController);
+    }
 
     if (controller) {
       if (Array.isArray(controller.middleware)) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -140,8 +140,8 @@ function addSiteController(router, site, providers) {
       const subsiteController = files.tryRequire(site.dir);
 
       // default _.merge overrides values in arrays :facepalm:
-      _.mergeWith(controller, subsiteController, function (par, sub) {
-        if (_.isArray(par) && _.isArray(sub)) {
+      _.mergeWith(controller, subsiteController, (par, sub) => {
+        if (Array.isArray(par) && Array.isArray(sub)) {
           return par.concat(sub);
         }
       });

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -139,12 +139,14 @@ function addSiteController(router, site, providers) {
     if (site.subsite) {
       const subsiteController = files.tryRequire(site.dir);
 
-      // default _.merge overrides values in arrays :facepalm:
-      _.mergeWith(controller, subsiteController, (par, sub) => {
-        if (Array.isArray(par) && Array.isArray(sub)) {
-          return par.concat(sub);
-        }
-      });
+      if (subsiteController) {
+        // default _.merge overrides values in arrays :facepalm:
+        _.mergeWith(controller, subsiteController, (par, sub) => {
+          if (Array.isArray(par) && Array.isArray(sub)) {
+            return par.concat(sub);
+          }
+        });
+      }
     }
 
     if (controller) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -132,7 +132,7 @@ function addSiteController(router, site, providers) {
   // fetches itself if it is the main site
   const parent = siteService.getParentSite(site.slug);
 
-  if (parent.dir) {
+  if (parent && parent.dir) {
     const controller = files.tryRequire(parent.dir);
 
     // merge in subsiteController options

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -140,7 +140,7 @@ function addSiteController(router, site, providers) {
       const subsiteController = files.tryRequire(site.dir);
 
       // default _.merge overrides values in arrays :facepalm:
-      _.mergeWith(controller, subsiteController, function(par, sub) {
+      _.mergeWith(controller, subsiteController, function (par, sub) {
         if (_.isArray(par) && _.isArray(sub)) {
           return par.concat(sub);
         }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -139,7 +139,12 @@ function addSiteController(router, site, providers) {
     if (site.subsite) {
       const subsiteController = files.tryRequire(site.dir);
 
-      _.merge(controller, subsiteController);
+      // default _.merge overrides values in arrays :facepalm:
+      _.mergeWith(controller, subsiteController, function(par, sub) {
+        if (_.isArray(par) && _.isArray(sub)) {
+          return par.concat(sub);
+        }
+      });
     }
 
     if (controller) {

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -412,18 +412,22 @@ describe(_.startCase(filename), function () {
 
     it('merges in subsite controller', function () {
       const siteDir = 'some-location',
-        router = createMockRouter(),
+        paths = [],
+        router = {
+          get(route) {
+            paths.push(route);
+          }
+        },
         site = { dir: siteDir, subsite: 'some-subsite' };
 
       siteService.getParentSite.returns(_.cloneDeep(site));
       sandbox.stub(files, 'tryRequire');
-      sandbox.stub(_, 'mergeWith');
 
       files.tryRequire.onFirstCall().returns({ routes: [{ path: '/foo' }] });
       files.tryRequire.onSecondCall().returns({ routes: [{ path: '/bar' }] });
 
       fn(router, site);
-      sinon.assert.calledOnce(_.mergeWith);
+      expect(paths).to.deep.equal(['/foo', '/bar']);
     });
   });
 

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -423,8 +423,8 @@ describe(_.startCase(filename), function () {
       siteService.getParentSite.returns(_.cloneDeep(site));
       sandbox.stub(files, 'tryRequire');
 
-      files.tryRequire.onFirstCall().returns({ routes: [{ path: '/foo' }] });
-      files.tryRequire.onSecondCall().returns({ routes: [{ path: '/bar' }] });
+      files.tryRequire.onFirstCall().returns({ routes: [{ path: '/foo' }], foo: 'bar' });
+      files.tryRequire.onSecondCall().returns({ routes: [{ path: '/bar' }], foo: 'bat' });
 
       fn(router, site);
       expect(paths).to.deep.equal(['/foo', '/bar']);

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -110,6 +110,10 @@ describe(_.startCase(filename), function () {
   describe('addSite', function () {
     const fn = lib[this.title];
 
+    beforeEach(function () {
+      sandbox.stub(siteService);
+    });
+
     it('adds controllers', function () {
       const router = createMockRouter(),
         innerRouter = createMockRouter();
@@ -119,7 +123,6 @@ describe(_.startCase(filename), function () {
       sandbox.stub(files, 'tryRequire');
       sandbox.stub(files, 'getFiles');
       sandbox.stub(files, 'getComponents');
-      sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(true);
       files.tryRequire.returns(_.noop);
@@ -143,7 +146,7 @@ describe(_.startCase(filename), function () {
       sandbox.stub(files, 'tryRequire');
       sandbox.stub(files, 'getFiles');
       sandbox.stub(files, 'getComponents');
-      sandbox.stub(siteService, 'sites');
+      siteService.getParentSite.returns(_.cloneDeep(siteStub));
 
       files.fileExists.returns(true);
       files.tryRequire.returns(_.noop);
@@ -168,7 +171,7 @@ describe(_.startCase(filename), function () {
       sandbox.stub(files, 'tryRequire');
       sandbox.stub(files, 'getFiles');
       sandbox.stub(files, 'getComponents');
-      sandbox.stub(siteService, 'sites');
+      siteService.getParentSite.returns(_.cloneDeep(siteStub));
 
       files.fileExists.returns(true);
       files.tryRequire.onCall(0).returns({
@@ -193,7 +196,7 @@ describe(_.startCase(filename), function () {
       sandbox.stub(files, 'tryRequire');
       sandbox.stub(files, 'getFiles');
       sandbox.stub(files, 'getComponents');
-      sandbox.stub(siteService, 'sites');
+      siteService.getParentSite.returns(_.cloneDeep(siteStub));
 
       files.fileExists.returns(true);
       files.tryRequire.onCall(0).returns(null);
@@ -217,7 +220,6 @@ describe(_.startCase(filename), function () {
       sandbox.stub(files, 'fileExists');
       sandbox.stub(files, 'tryRequire');
       sandbox.stub(files, 'getComponents');
-      sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(true);
       siteService.sites.returns({
@@ -240,7 +242,6 @@ describe(_.startCase(filename), function () {
       sandbox.stub(files, 'fileExists');
       sandbox.stub(files, 'tryRequire');
       sandbox.stub(files, 'getComponents');
-      sandbox.stub(siteService, 'sites');
 
       files.fileExists.returns(false);
       siteService.sites.returns({
@@ -309,9 +310,15 @@ describe(_.startCase(filename), function () {
   describe('addSiteController', function () {
     const fn = lib[this.title];
 
+    beforeEach(function () {
+      sandbox.stub(siteService);
+    });
+
     it('does nothing if there is no site directory', function () {
       const router = {},
         site = {};
+
+      siteService.getParentSite.returns(_.cloneDeep(site));
 
       fn(router, site);
     });
@@ -321,6 +328,7 @@ describe(_.startCase(filename), function () {
         router = {},
         site = { dir: siteDir };
 
+      siteService.getParentSite.returns(_.cloneDeep(site));
       sandbox.stub(files, 'tryRequire');
 
       files.tryRequire.returns(false);
@@ -333,6 +341,7 @@ describe(_.startCase(filename), function () {
         router = {},
         site = { dir: siteDir };
 
+      siteService.getParentSite.returns(_.cloneDeep(site));
       sandbox.stub(files, 'tryRequire');
 
       files.tryRequire.returns({});
@@ -350,6 +359,7 @@ describe(_.startCase(filename), function () {
         },
         site = { dir: siteDir };
 
+      siteService.getParentSite.returns(_.cloneDeep(site));
       sandbox.stub(files, 'tryRequire');
 
       files.tryRequire.returns({
@@ -375,6 +385,7 @@ describe(_.startCase(filename), function () {
         },
         site = { dir: siteDir };
 
+      siteService.getParentSite.returns(_.cloneDeep(site));
       sandbox.stub(files, 'tryRequire');
 
       files.tryRequire.returns({
@@ -391,11 +402,28 @@ describe(_.startCase(filename), function () {
         router = {},
         site = { dir: siteDir };
 
+      siteService.getParentSite.returns(_.cloneDeep(site));
       sandbox.stub(files, 'tryRequire');
 
       files.tryRequire.returns({});
 
       fn(router, site);
+    });
+
+    it('merges in subsite controller', function () {
+      const siteDir = 'some-location',
+        router = createMockRouter(),
+        site = { dir: siteDir, subsite: 'some-subsite' };
+
+      siteService.getParentSite.returns(_.cloneDeep(site));
+      sandbox.stub(files, 'tryRequire');
+      sandbox.stub(_, 'mergeWith');
+
+      files.tryRequire.onFirstCall().returns({ routes: [{ path: '/foo' }] });
+      files.tryRequire.onSecondCall().returns({ routes: [{ path: '/bar' }] });
+
+      fn(router, site);
+      sinon.assert.calledOnce(_.mergeWith);
     });
   });
 

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -429,6 +429,26 @@ describe(_.startCase(filename), function () {
       fn(router, site);
       expect(paths).to.deep.equal(['/foo', '/bar']);
     });
+
+    it('uses parent controller if subsite controller does not exist', function () {
+      const siteDir = 'some-location',
+        paths = [],
+        router = {
+          get(route) {
+            paths.push(route);
+          }
+        },
+        site = { dir: siteDir, subsite: 'some-subsite' };
+
+      siteService.getParentSite.returns(_.cloneDeep(site));
+      sandbox.stub(files, 'tryRequire');
+
+      files.tryRequire.onFirstCall().returns({ routes: [{ path: '/foo' }], foo: 'bar' });
+      files.tryRequire.onSecondCall().returns(null);
+
+      fn(router, site);
+      expect(paths).to.deep.equal(['/foo']);
+    });
   });
 
   describe('addAuthenticationRoutes', function () {

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -74,7 +74,7 @@ function createPage(ref, user) {
       users,
       history: [{action: 'create', timestamp: NOW, users }],
       siteSlug: site.slug,
-      subsiteSlug: site.subsiteSlug
+      subsiteSlug: site.subsiteSlug || null
     };
 
   return putMeta(ref, meta);
@@ -93,7 +93,7 @@ function createLayout(ref, user) {
       title: '',
       history: [{ action: 'create', timestamp: NOW, users }],
       siteSlug: site.slug,
-      subsiteSlug: site.subsiteSlug
+      subsiteSlug: site.subsiteSlug || null
     };
 
   return putMeta(ref, meta);

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -59,6 +59,7 @@ function publishPage(uri, publishMeta, user) {
 function createPage(ref, user) {
   const NOW = new Date().toISOString(),
     users = [userOrRobot(user)],
+    site = sitesService.getSiteFromPrefix(ref.substring(0, ref.indexOf('/_pages'))),
     meta = {
       createdAt: NOW,
       archived: false,
@@ -72,7 +73,8 @@ function createPage(ref, user) {
       authors: [],
       users,
       history: [{action: 'create', timestamp: NOW, users }],
-      siteSlug: sitesService.getSiteFromPrefix(ref.substring(0, ref.indexOf('/_pages'))).slug
+      siteSlug: site.slug,
+      subsiteSlug: site.subsiteSlug
     };
 
   return putMeta(ref, meta);
@@ -81,6 +83,7 @@ function createPage(ref, user) {
 function createLayout(ref, user) {
   const NOW = new Date().toISOString(),
     users = [userOrRobot(user)],
+    site = sitesService.getSiteFromPrefix(ref.substring(0, ref.indexOf('/_layouts'))),
     meta = {
       createdAt: NOW,
       published: false,
@@ -89,7 +92,8 @@ function createLayout(ref, user) {
       firstPublishTime: null,
       title: '',
       history: [{ action: 'create', timestamp: NOW, users }],
-      siteSlug: sitesService.getSiteFromPrefix(ref.substring(0, ref.indexOf('/_layouts'))).slug
+      siteSlug: site.slug,
+      subsiteSlug: site.subsiteSlug
     };
 
   return putMeta(ref, meta);

--- a/lib/services/metadata.js
+++ b/lib/services/metadata.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash'),
   bus = require('./bus'),
-  { replaceVersion } = require('clayutils'),
+  { replaceVersion, getPrefix } = require('clayutils'),
   sitesService = require('./sites');
 var db = require('./db');
 
@@ -59,7 +59,7 @@ function publishPage(uri, publishMeta, user) {
 function createPage(ref, user) {
   const NOW = new Date().toISOString(),
     users = [userOrRobot(user)],
-    site = sitesService.getSiteFromPrefix(ref.substring(0, ref.indexOf('/_pages'))),
+    site = sitesService.getSiteFromPrefix(getPrefix(ref)),
     meta = {
       createdAt: NOW,
       archived: false,
@@ -83,7 +83,7 @@ function createPage(ref, user) {
 function createLayout(ref, user) {
   const NOW = new Date().toISOString(),
     users = [userOrRobot(user)],
-    site = sitesService.getSiteFromPrefix(ref.substring(0, ref.indexOf('/_layouts'))),
+    site = sitesService.getSiteFromPrefix(getPrefix(ref)),
     meta = {
       createdAt: NOW,
       published: false,

--- a/lib/services/metadata.test.js
+++ b/lib/services/metadata.test.js
@@ -123,6 +123,17 @@ describe(_.startCase(filename), function () {
 
     it('creates page meta', function () {
       db.putMeta.returns(Promise.resolve());
+      siteService.getSiteFromPrefix.returns({ slug: 'foo' });
+
+      return fn('domain.com/_pages/id/meta', { username: 'foo', provider: 'bar' })
+        .then(() => {
+          sinon.assert.calledOnce(db.putMeta);
+          sinon.assert.calledOnce(bus.publish);
+        });
+    });
+
+    it('creates page meta with subsite', function () {
+      db.putMeta.returns(Promise.resolve());
       siteService.getSiteFromPrefix.returns({ slug: 'foo', subsiteSlug: 'foo/bar' });
 
       return fn('domain.com/_pages/id/meta', { username: 'foo', provider: 'bar' })
@@ -137,6 +148,17 @@ describe(_.startCase(filename), function () {
     const fn = lib[this.title];
 
     it('creates layout meta', function () {
+      db.putMeta.returns(Promise.resolve());
+      siteService.getSiteFromPrefix.returns({ slug: 'foo' });
+
+      return fn('domain.com/_pages/id/meta', { username: 'foo', provider: 'bar' })
+        .then(() => {
+          sinon.assert.calledOnce(db.putMeta);
+          sinon.assert.calledOnce(bus.publish);
+        });
+    });
+
+    it('creates layout meta with subsite', function () {
       db.putMeta.returns(Promise.resolve());
       siteService.getSiteFromPrefix.returns({ slug: 'foo', subsiteSlug: 'foo/bar' });
 

--- a/lib/services/metadata.test.js
+++ b/lib/services/metadata.test.js
@@ -123,7 +123,7 @@ describe(_.startCase(filename), function () {
 
     it('creates page meta', function () {
       db.putMeta.returns(Promise.resolve());
-      siteService.getSiteFromPrefix.returns({ slug: 'foo' });
+      siteService.getSiteFromPrefix.returns({ slug: 'foo', subsiteSlug: 'foo/bar' });
 
       return fn('domain.com/_pages/id/meta', { username: 'foo', provider: 'bar' })
         .then(() => {
@@ -138,7 +138,7 @@ describe(_.startCase(filename), function () {
 
     it('creates layout meta', function () {
       db.putMeta.returns(Promise.resolve());
-      siteService.getSiteFromPrefix.returns({ slug: 'foo' });
+      siteService.getSiteFromPrefix.returns({ slug: 'foo', subsiteSlug: 'foo/bar' });
 
       return fn('domain.com/_pages/id/meta', { username: 'foo', provider: 'bar' })
         .then(() => {

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -51,7 +51,7 @@ function getSites() {
   const fullConfig = {},
     instanceSitesFolder = path.resolve('sites');
 
-  function createSiteConfig (site) {
+  function createSiteConfig(site) {
     const dir = path.join(instanceSitesFolder, site),
       siteConfig = files.getYaml(path.join(dir, 'config')),
       localConfig = files.getYaml(path.join(dir, 'local'));
@@ -120,7 +120,8 @@ function getSites() {
 
 /**
  * returns all of the sites with the same slug
- * @param {*} slug 
+ * @param {string} slug
+ * @return {array}
  */
 function getSiteFamily(slug) {
   return _.filter(module.exports.sites(), function (site) {
@@ -130,7 +131,8 @@ function getSiteFamily(slug) {
 
 /**
  * returns the main site for a site family
- * @param {*} slug 
+ * @param {string} slug
+ * @returns {object}
  */
 function getParentSite(slug) {
   return module.exports.sites()[slug];

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -134,12 +134,12 @@ function getSiteFamily(slug) {
 }
 
 /**
- * returns the main site for a site family
+ * returns the main site for a site family. If it can't find a parent, return itself
  * @param {string} slug
  * @returns {object}
  */
 function getParentSite(slug) {
-  return module.exports.sites()[slug];
+  return module.exports.sites()[slug] || slug;
 }
 
 /**

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -107,11 +107,15 @@ function getSites() {
         subsiteConfig.slug = site;
         subsiteConfig.subsite = subsite;
 
+        // allows sites to have same slug, but use different key for amphora-search
+        subsiteConfig.amphoraKey = subsiteKey;
+
         fullConfig[subsiteKey] = subsiteConfig;
       });
     }
 
     // add site config to the sites map
+    siteConfig.amphoraKey = siteConfig.slug;
     fullConfig[siteConfig.slug] = siteConfig;
   });
 

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -70,7 +70,12 @@ function getSites() {
     siteConfig.slug = site;
     siteConfig.path = normalizePath(siteConfig.path);
     siteConfig.dir = dir;
-    siteConfig.assetPath = normalizePath(siteConfig.assetPath);
+
+    // subsites might not have this and we don't want to override parent site values with an empty string
+    if (siteConfig.assetPath) {
+      siteConfig.assetPath = normalizePath(siteConfig.assetPath);
+    }
+
     siteConfig.assetDir = normalizeDirectory(siteConfig.assetDir || 'public');
     siteConfig.prefix = siteConfig.path && siteConfig.path.length > 1 ? siteConfig.host + siteConfig.path : siteConfig.host;
 
@@ -107,7 +112,7 @@ function getSites() {
         subsiteConfig.slug = site;
         subsiteConfig.subsite = subsite;
 
-        // allows sites to have same slug, but use different key for amphora-search
+        // allows subsites to have same slug, but use different key for amphora-search
         subsiteConfig.amphoraKey = subsiteKey;
 
         fullConfig[subsiteKey] = subsiteConfig;

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -92,31 +92,28 @@ function getSites() {
       SUBSITES_DIR = 'subsites',
       subsiteDir = path.join(instanceSitesFolder, site, SUBSITES_DIR);
 
-    // if this site has subsites, we have a bit more work to do
-    if (files.fileExists(subsiteDir)) {
-      const siteDefaults = _.cloneDeep(siteConfig);
-
-      // run through subsites, and generate from their configs
-      files.getFolders(subsiteDir).forEach( subsite => {
-        // start with defaults from main site
-        const subsiteConfig = _.cloneDeep(siteDefaults),
-          subsiteKey = `${site}/${SUBSITES_DIR}/${subsite}`,
-          subsiteOverridesConfig = createSiteConfig(subsiteKey);
-
-        _.assign(subsiteConfig, subsiteOverridesConfig);
-        subsiteConfig.slug = site;
-        subsiteConfig.subsite = subsite;
-
-        // allows subsites to have same slug, but use different key for amphora-search
-        subsiteConfig.amphoraKey = subsiteKey;
-
-        fullConfig[subsiteKey] = subsiteConfig;
-      });
-    }
-
-    // add site config to the sites map
     if (siteConfig) {
-      siteConfig.amphoraKey = siteConfig.slug;
+      // if this site has subsites, we have a bit more work to do
+      if (files.fileExists(subsiteDir)) {
+        const siteDefaults = _.cloneDeep(siteConfig);
+
+        // run through subsites, and generate from their configs
+        files.getFolders(subsiteDir).forEach( subsite => {
+          // start with defaults from main site
+          const subsiteConfig = _.cloneDeep(siteDefaults),
+            subsiteSlug = `${site}/${subsite}`,
+            subsiteOverridesConfig = createSiteConfig(`${site}/${SUBSITES_DIR}/${subsite}`);
+
+          _.assign(subsiteConfig, subsiteOverridesConfig);
+          subsiteConfig.slug = site;
+          subsiteConfig.subsite = subsite;
+
+          // allows subsites to have same slug, but use different key for amphora-search
+          subsiteConfig.subsiteSlug = subsiteSlug;
+          fullConfig[subsiteSlug] = subsiteConfig;
+        });
+      }
+      // add site config to the sites map
       fullConfig[siteConfig.slug] = siteConfig;
     }
   });

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -115,8 +115,10 @@ function getSites() {
     }
 
     // add site config to the sites map
-    siteConfig.amphoraKey = siteConfig.slug;
-    fullConfig[siteConfig.slug] = siteConfig;
+    if (siteConfig) {
+      siteConfig.amphoraKey = siteConfig.slug;
+      fullConfig[siteConfig.slug] = siteConfig;
+    }
   });
 
   return fullConfig;

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -136,12 +136,12 @@ function getSiteFamily(slug) {
 }
 
 /**
- * returns the main site for a site family. If it can't find a parent, return itself
+ * returns the main site for a site family.
  * @param {string} slug
  * @returns {object}
  */
 function getParentSite(slug) {
-  return module.exports.sites()[slug] || slug;
+  return module.exports.sites()[slug];
 }
 
 /**

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -66,23 +66,18 @@ function getSites() {
       _.assign(siteConfig, localConfig);
     }
 
-    // normalize
-    siteConfig.slug = site;
-    siteConfig.path = normalizePath(siteConfig.path);
-    siteConfig.dir = dir;
-
-    // subsites might not have this and we don't want to override parent site values with an empty string
-    if (siteConfig.assetPath) {
-      siteConfig.assetPath = normalizePath(siteConfig.assetPath);
-    }
-
-    siteConfig.assetDir = normalizeDirectory(siteConfig.assetDir || 'public');
-    siteConfig.prefix = siteConfig.path && siteConfig.path.length > 1 ? siteConfig.host + siteConfig.path : siteConfig.host;
-
     // check to make sure sites have default properties
     if (!siteConfig.host) {
       throw new Error('Missing host in site config');
     }
+
+    // normalize
+    siteConfig.slug = site;
+    siteConfig.path = normalizePath(siteConfig.path);
+    siteConfig.dir = dir;
+    siteConfig.assetPath = normalizePath(siteConfig.assetPath);
+    siteConfig.assetDir = normalizeDirectory(siteConfig.assetDir || 'public');
+    siteConfig.prefix = siteConfig.path && siteConfig.path.length > 1 ? siteConfig.host + siteConfig.path : siteConfig.host;
 
     if (!siteConfig.protocol) {
       log('warn', `A protocol property ('http' or 'https') was not found for site '${site}', it will default to 'http'`);

--- a/lib/services/sites.js
+++ b/lib/services/sites.js
@@ -51,7 +51,7 @@ function getSites() {
   const fullConfig = {},
     instanceSitesFolder = path.resolve('sites');
 
-  files.getFolders(instanceSitesFolder).forEach(function (site) {
+  function createSiteConfig (site) {
     const dir = path.join(instanceSitesFolder, site),
       siteConfig = files.getYaml(path.join(dir, 'config')),
       localConfig = files.getYaml(path.join(dir, 'local'));
@@ -84,11 +84,56 @@ function getSites() {
       siteConfig.protocol = 'http';
     }
 
+    return siteConfig;
+  }
+
+  files.getFolders(instanceSitesFolder).forEach(site => {
+    const siteConfig = createSiteConfig(site),
+      SUBSITES_DIR = 'subsites',
+      subsiteDir = path.join(instanceSitesFolder, site, SUBSITES_DIR);
+
+    // if this site has subsites, we have a bit more work to do
+    if (files.fileExists(subsiteDir)) {
+      const siteDefaults = _.cloneDeep(siteConfig);
+
+      // run through subsites, and generate from their configs
+      files.getFolders(subsiteDir).forEach( subsite => {
+        // start with defaults from main site
+        const subsiteConfig = _.cloneDeep(siteDefaults),
+          subsiteKey = `${site}/${SUBSITES_DIR}/${subsite}`,
+          subsiteOverridesConfig = createSiteConfig(subsiteKey);
+
+        _.assign(subsiteConfig, subsiteOverridesConfig);
+        subsiteConfig.slug = site;
+        subsiteConfig.subsite = subsite;
+
+        fullConfig[subsiteKey] = subsiteConfig;
+      });
+    }
+
     // add site config to the sites map
     fullConfig[siteConfig.slug] = siteConfig;
   });
 
   return fullConfig;
+}
+
+/**
+ * returns all of the sites with the same slug
+ * @param {*} slug 
+ */
+function getSiteFamily(slug) {
+  return _.filter(module.exports.sites(), function (site) {
+    return site.slug === slug;
+  });
+}
+
+/**
+ * returns the main site for a site family
+ * @param {*} slug 
+ */
+function getParentSite(slug) {
+  return module.exports.sites()[slug];
 }
 
 /**
@@ -131,6 +176,8 @@ function getSiteFromPrefix(prefix) {
   return site; // Return the site
 }
 
+module.exports.getSiteFamily = getSiteFamily;
+module.exports.getParentSite = getParentSite;
 module.exports.sites = _.memoize(getSites);
 module.exports.get = getSite;
 module.exports.getSite = getSite;

--- a/lib/services/sites.test.js
+++ b/lib/services/sites.test.js
@@ -243,6 +243,24 @@ describe(_.startCase(filename), function () {
     });
   });
 
+  describe('getSiteFamily', function () {
+    const fn = lib[this.title];
+
+    it('gets all sites with the same slug', function () {
+      sandbox.stub(lib, 'sites').returns(mockSites);
+      expect(fn('c')).to.deep.equal([mockSites.c, mockSites['c/subsites/d']]);
+    });
+  });
+
+  describe('getParentSite', function () {
+    const fn = lib[this.title];
+
+    it('returns site based on slug', function () {
+      sandbox.stub(lib, 'sites').returns(mockSites);
+      expect(fn('c')).to.eql(mockSites.c);
+    });
+  });
+
   describe('get', function () {
     const fn = lib[this.title];
 

--- a/lib/services/sites.test.js
+++ b/lib/services/sites.test.js
@@ -19,7 +19,8 @@ describe(_.startCase(filename), function () {
         prefix: 'd/e',
         assetDir: 'public',
         assetPath: '/e',
-        protocol: 'http'
+        protocol: 'http',
+        amphoraKey: 'a'
       },
       b: {
         dir: 'z/b',
@@ -29,7 +30,8 @@ describe(_.startCase(filename), function () {
         prefix: 'd/e',
         assetDir: 'public',
         assetPath: '/e',
-        protocol: 'http'
+        protocol: 'http',
+        amphoraKey: 'b'
       },
       c: {
         dir: 'z/c',
@@ -39,7 +41,20 @@ describe(_.startCase(filename), function () {
         prefix: 'h/i/j',
         assetDir: 'public',
         assetPath: '/i/j',
-        protocol: 'http'
+        protocol: 'http',
+        amphoraKey: 'c'
+      },
+      'c/subsites/d': {
+        dir: 'z/c/subsites/d',
+        slug: 'c',
+        host: 'h',
+        path: '/k',
+        prefix: 'h/k',
+        assetDir: 'public',
+        assetPath: '/k',
+        protocol: 'http',
+        amphoraKey: 'c/subsites/d',
+        subsite: 'd'
       }
     },
     mockSitesWithoutPaths = {
@@ -51,7 +66,8 @@ describe(_.startCase(filename), function () {
         prefix: 'd',
         assetDir: 'public',
         assetPath: '',
-        protocol: 'http'
+        protocol: 'http',
+        amphoraKey: 'a'
       },
       b: {
         dir: 'z/b',
@@ -61,7 +77,8 @@ describe(_.startCase(filename), function () {
         prefix: 'd',
         assetDir: 'public',
         assetPath: '',
-        protocol: 'http'
+        protocol: 'http',
+        amphoraKey: 'b'
       }
     };
 
@@ -106,6 +123,7 @@ describe(_.startCase(filename), function () {
     sandbox.stub(path, 'resolve');
     sandbox.stub(files, 'getFolders');
     sandbox.stub(files, 'getYaml');
+    sandbox.stub(files, 'fileExists');
 
     // clear the caches
     lib.sites.cache = new _.memoize.Cache();
@@ -119,16 +137,42 @@ describe(_.startCase(filename), function () {
     const fn = lib[this.title];
 
     it('gets', function () {
-      files.getFolders.returns(['a', 'b', 'c']);
+      files.getFolders.onFirstCall().returns(['a', 'b', 'c']);
       path.resolve.returns('z');
+
+      // a/config.yaml + a/local.yaml
       files.getYaml.onFirstCall().returns(getMockSite());
       files.getYaml.onSecondCall().returns(getMockSite());
+      files.fileExists.onFirstCall().returns(false);
+
+      // b/config.yaml + b/local.yaml
       files.getYaml.onThirdCall().returns(getMockSite());
-      files.getYaml.onCall(4).returns({
-        assetPath: '/i/j',
+      files.getYaml.onCall(3).returns({
+        host: 'd',
+        path: '/e',
+        assetPath: '/e'
+      });
+      files.fileExists.onSecondCall().returns(false);
+
+      // c/config.yaml + c/local.yaml
+      files.getYaml.onCall(4).returns(getMockSite());
+      files.getYaml.onCall(5).returns({
         host: 'h',
         path: '/i/j',
-        prefix: 'h/i/j'
+        assetPath: '/i/j'
+      });
+      // site d is a subsite of site c
+      files.fileExists.onThirdCall().returns(true);
+      files.getFolders.onSecondCall().returns(['d']);
+
+      // d/config.yaml + d/local.yaml
+      files.getYaml.onCall(6).returns(getMockSite());
+      files.getYaml.onCall(7).returns({
+        slug: 'c',
+        host: 'h',
+        path: '/k',
+        assetPath: '/k',
+        subsite: 'd'
       });
 
       expect(fn()).to.deep.equal(mockSites);
@@ -167,16 +211,31 @@ describe(_.startCase(filename), function () {
     });
 
     it('adds in the `protocol` property and logs warning if it is not on the config', function () {
-      files.getFolders.returns(['a', 'b', 'c']);
+      files.getFolders.onFirstCall().returns(['a', 'b', 'c']);
       path.resolve.returns('z');
+      // site a
       files.getYaml.onFirstCall().returns(getMockSiteWithoutProtocol());
       files.getYaml.onSecondCall().returns(getMockSiteWithoutProtocol());
+      files.fileExists.onFirstCall().returns(false);
+      // site b
       files.getYaml.onThirdCall().returns(getMockSiteWithoutProtocol());
+      files.fileExists.onSecondCall().returns(false);
+      // site c
       files.getYaml.onCall(4).returns({
         assetPath: '/i/j',
         host: 'h',
         path: '/i/j',
         prefix: 'h/i/j'
+      });
+      // site d is a subsite
+      files.fileExists.onThirdCall().returns(true);
+      files.getFolders.onSecondCall().returns(['d']);
+      files.getYaml.onCall(6).returns({
+        slug: 'c',
+        host: 'h',
+        path: '/k',
+        assetPath: '/k',
+        subsite: 'd'
       });
 
       expect(fn()).to.deep.equal(mockSites);

--- a/lib/services/sites.test.js
+++ b/lib/services/sites.test.js
@@ -19,8 +19,7 @@ describe(_.startCase(filename), function () {
         prefix: 'd/e',
         assetDir: 'public',
         assetPath: '/e',
-        protocol: 'http',
-        amphoraKey: 'a'
+        protocol: 'http'
       },
       b: {
         dir: 'z/b',
@@ -30,8 +29,7 @@ describe(_.startCase(filename), function () {
         prefix: 'd/e',
         assetDir: 'public',
         assetPath: '/e',
-        protocol: 'http',
-        amphoraKey: 'b'
+        protocol: 'http'
       },
       c: {
         dir: 'z/c',
@@ -41,10 +39,9 @@ describe(_.startCase(filename), function () {
         prefix: 'h/i/j',
         assetDir: 'public',
         assetPath: '/i/j',
-        protocol: 'http',
-        amphoraKey: 'c'
+        protocol: 'http'
       },
-      'c/subsites/d': {
+      'c/d': {
         dir: 'z/c/subsites/d',
         slug: 'c',
         host: 'h',
@@ -53,7 +50,7 @@ describe(_.startCase(filename), function () {
         assetDir: 'public',
         assetPath: '/k',
         protocol: 'http',
-        amphoraKey: 'c/subsites/d',
+        subsiteSlug: 'c/d',
         subsite: 'd'
       }
     },
@@ -66,8 +63,7 @@ describe(_.startCase(filename), function () {
         prefix: 'd',
         assetDir: 'public',
         assetPath: '',
-        protocol: 'http',
-        amphoraKey: 'a'
+        protocol: 'http'
       },
       b: {
         dir: 'z/b',
@@ -77,8 +73,7 @@ describe(_.startCase(filename), function () {
         prefix: 'd',
         assetDir: 'public',
         assetPath: '',
-        protocol: 'http',
-        amphoraKey: 'b'
+        protocol: 'http'
       }
     };
 
@@ -248,7 +243,7 @@ describe(_.startCase(filename), function () {
 
     it('gets all sites with the same slug', function () {
       sandbox.stub(lib, 'sites').returns(mockSites);
-      expect(fn('c')).to.deep.equal([mockSites.c, mockSites['c/subsites/d']]);
+      expect(fn('c')).to.deep.equal([mockSites.c, mockSites['c/d']]);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "New York Media",
   "license": "MIT",
   "dependencies": {
-    "amphora-auth": "^1.0.0",
+    "amphora-auth": "git+ssh://git@github.com:clay/amphora-auth.git#subsite-support",
     "amphora-fs": "^1.0.1",
     "basic-auth": "^1.0.4",
     "bluebird": "^3.5.1",


### PR DESCRIPTION
dependencies:
- https://github.com/clay/amphora-auth/pull/26

adds subsite support. allows for the following file structure inside of sites:

```
sites
    - site-name
        - subsites
            - subsite-name
                - media
                index.js
                bootstrap.yaml
                config.yaml
    index.js
    bootstrap.yaml
    config.yaml
```

required config for subsites:
- protocol
- path
- host
- port
- assetPath