### PR TITLE
changes log level for 404s from ERROR to INFO

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -277,7 +277,7 @@ function renderExpressRoute(req, res, next) {
   return module.exports.renderUri(pageReference, req, res, hrStart)
     .catch((error) => {
       if (error.name === 'NotFoundError') {
-        log('error', `could not find resource ${req.uri}`, {
+        log('info', `could not find resource ${req.uri}`, {
           message: error.message
         });
         next();


### PR DESCRIPTION
When a page does not exist (ie. 404) Amphora was producing an ERROR-level (50) message. This devalued the meaning of the ERROR level by polluting logs with errors for things like requests to '/favicon' that browsers automatically make.

A 404 is not an error, it's expected behavior.
I think INFO is a suitable level for 404s because they are mostly noise; no additional value is provided to what one can glean from making a client-side request.