### PR TITLE
Subsite controller fix

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -225,7 +225,17 @@ function addSite(router, { providers, sessionStore }, site) {
       addControllerRoutes(siteRouter);
       addAuthenticationRoutes(siteRouter);
 
-      if (!!siteControllerConfig) {
+      let hasSiteController = !!siteControllerConfig;
+      // if it's a subsite, check to see if parent has a config
+      if (!hasSiteController && site.subsite) {
+        const parent = siteService.getParentSite(site.slug);
+
+        if (parent && parent.dir) {
+          hasSiteController = !!files.tryRequire(parent.dir);
+        }
+      }
+
+      if (!!hasSiteController) {
         // optional module to load routes and configuration defined from outside of amphora
         router.use(path, addSiteController(siteRouter, site, providers));
       }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -236,7 +236,7 @@ function addSite(router, { providers, sessionStore }, site) {
         }
       }
 
-      if (!!hasSiteController) {
+      if (hasSiteController) {
         // optional module to load routes and configuration defined from outside of amphora
         router.use(path, addSiteController(siteRouter, site, providers));
       }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -226,6 +226,7 @@ function addSite(router, { providers, sessionStore }, site) {
       addAuthenticationRoutes(siteRouter);
 
       let hasSiteController = !!siteControllerConfig;
+
       // if it's a subsite, check to see if parent has a config
       if (!hasSiteController && site.subsite) {
         const parent = siteService.getParentSite(site.slug);

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -212,6 +212,58 @@ describe(_.startCase(filename), function () {
       });
     });
 
+    it('uses parents controller if subsite doesnt have one', function () {
+      const router = createMockRouter(),
+        innerRouter = createMockRouter(),
+        siteStub = { slug: 'example', dir: '/example', assetDir: 'example', subsite: 'uk' };
+
+      sandbox.stub(express, 'Router').callsFake(_.constant(innerRouter));
+      sandbox.stub(files, 'fileExists');
+      sandbox.stub(files, 'tryRequire');
+      sandbox.stub(files, 'getFiles');
+      sandbox.stub(files, 'getComponents');
+      siteService.getParentSite.returns(_.cloneDeep(siteStub));
+
+      files.fileExists.returns(true);
+      files.tryRequire.onCall(0).returns(null);
+      files.tryRequire.returns(_.noop);
+      files.getFiles.returns(['a.b, c.d, e.f']);
+
+      return fn(
+        router,
+        { providers: ['ldap'] },
+        siteStub
+      ).then(function () {
+        expect(files.tryRequire.callCount).to.equal(9);
+      });
+    });
+
+    it('doesnt set up subsite controller if parent doesnt have one', function () {
+      const router = createMockRouter(),
+        innerRouter = createMockRouter(),
+        siteStub = { slug: 'example', dir: '/example', assetDir: 'example', subsite: 'uk' };
+
+      sandbox.stub(express, 'Router').callsFake(_.constant(innerRouter));
+      sandbox.stub(files, 'fileExists');
+      sandbox.stub(files, 'tryRequire');
+      sandbox.stub(files, 'getFiles');
+      sandbox.stub(files, 'getComponents');
+      siteService.getParentSite.returns(null);
+
+      files.fileExists.returns(true);
+      files.tryRequire.onCall(0).returns(null);
+      files.tryRequire.returns(_.noop);
+      files.getFiles.returns(['a.b, c.d, e.f']);
+
+      return fn(
+        router,
+        { providers: ['ldap'] },
+        siteStub
+      ).then(function () {
+        expect(files.tryRequire.callCount).to.equal(6);
+      });
+    });
+
     it('throws on bad site', function () {
       const router = createMockRouter(),
         innerRouter = createMockRouter();


### PR DESCRIPTION
If a subsite didn't have an index.js, amphora wasn't registering its routes. This fixes that.