### PR TITLE
Adds middleware to the same Layer as the renderer

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -215,10 +215,10 @@ function addSite(router, { providers, sessionStore }, site) {
   return plugins.initPlugins(siteRouter, site)
     .then(() => {
       const siteControllerConfig = site.dir ? files.tryRequire(site.dir) : {},
-        midleware = _.get(siteControllerConfig, 'middleware', null);
+        middleware = _.get(siteControllerConfig, 'middleware', null);
 
-      if (Array.isArray(midleware)) {
-        siteRouter.use(midleware);
+      if (Array.isArray(middleware)) {
+        siteRouter.use(middleware);
       }
 
       // amphora api routes added first so they're handled before site-specific routes which are generally registering less specific paths

--- a/lib/services/attachRoutes.js
+++ b/lib/services/attachRoutes.js
@@ -46,10 +46,13 @@ function normalizeRedirectPath(redirect, site) {
  * @param {Router} router
  * @param {Object} route
  * @param {String} route.path
+ * @param {Object[]} middleware
  * @return {Router}
  */
-function attachPlainRoute(router, { path }) {
-  return router.get(path, render);
+function attachPlainRoute(router, { path }, middleware) {
+  const handlers = middleware.concat(render);
+
+  return router.get(path, handlers);
 }
 
 /**
@@ -59,14 +62,16 @@ function attachPlainRoute(router, { path }) {
  * @param {String} route.path
  * @param {String} route.redirect
  * @param {Object} site
+ * @param {Object[]} middleware
  * @return {Router}
  */
-function attachRedirect(router, { path, redirect }, site) {
-  redirect = normalizeRedirectPath(redirect, site);
+function attachRedirect(router, { path, redirect }, site, middleware) {
+  function redirectFn(req, res) {
+    res.redirect(301, normalizeRedirectPath(redirect, site));
+  }
+  const handlers = middleware.concat(redirectFn);
 
-  return router.get(path, (req, res) => {
-    res.redirect(301, redirect);
-  });
+  return router.get(path, handlers);
 }
 
 /**
@@ -75,10 +80,13 @@ function attachRedirect(router, { path, redirect }, site) {
  * @param {Object} route
  * @param {String} route.path
  * @param {String} route.dynamicPage
+ * @param {Object[]} middleware
  * @return {Router}
  */
-function attachDynamicRoute(router, { path, dynamicPage }) {
-  return router.get(path, render.renderDynamicRoute(dynamicPage));
+function attachDynamicRoute(router, { path, dynamicPage }, middleware) {
+  const handlers = middleware.concat(render.renderDynamicRoute(dynamicPage));
+
+  return router.get(path, handlers);
 }
 
 /**
@@ -89,22 +97,19 @@ function attachDynamicRoute(router, { path, dynamicPage }) {
  * @return {Router}
  */
 function parseHandler(router, routeObj, site) {
-  const { redirect, dynamicPage, path, middleware } = routeObj;
+  const { redirect, dynamicPage, path } = routeObj,
+    middleware = routeObj.middleware || [];
 
   if (!validPath(path, site)) {
     return;
   }
 
-  if (middleware) {
-    router.use(path, middleware);
-  }
-
   if (redirect) {
-    return attachRedirect(router, routeObj, site);
+    return attachRedirect(router, routeObj, site, middleware);
   } else if (dynamicPage) {
-    return attachDynamicRoute(router, routeObj); // Pass in the page ID
+    return attachDynamicRoute(router, routeObj, middleware); // Pass in the page ID
   } else {
-    return attachPlainRoute(router, routeObj);
+    return attachPlainRoute(router, routeObj, middleware);
   }
 }
 

--- a/lib/services/attachRoutes.test.js
+++ b/lib/services/attachRoutes.test.js
@@ -4,6 +4,7 @@ const _ = require('lodash'),
   filename = __filename.split('/').pop().split('.').shift(),
   lib = require('./' + filename),
   sinon = require('sinon'),
+  MIDDLEWARE = () => {},
   expect = require('chai').expect;
 
 describe(_.startCase(filename), function () {
@@ -13,7 +14,7 @@ describe(_.startCase(filename), function () {
       { path: '/section/' },
       { path: '/section', redirect: '/section/' },
       { path: '/news/:tag', dynamicPage: 'somePageId' },
-      { path: '/example', middleware: [() => {}] }
+      { path: '/example', middleware: [MIDDLEWARE] }
     ],
     siteConfigMock = {};
 
@@ -33,15 +34,11 @@ describe(_.startCase(filename), function () {
   describe('attachRoutes', function () {
     it('attaches routes if passed in', function () {
       const paths = [],
-        middlewares = [],
         router = {
           get(path) {
             // testing if the paths are added,
             // we're checking the paths array after each test
             paths.push(path);
-          },
-          use(path, middleware) {
-            middlewares.push(middleware);
           }
         };
 
@@ -52,11 +49,10 @@ describe(_.startCase(filename), function () {
     it('attaches middlewares if passed in', function () {
       const middlewares = [],
         router = {
-          get(path) {
-            return path;
-          },
-          use(path, middleware) {
-            middlewares.push(middleware);
+          get(path, middleware) {
+            if (middleware[0] === MIDDLEWARE) {
+              middlewares.push(MIDDLEWARE);
+            }
             return path;
           }
         };
@@ -76,7 +72,7 @@ describe(_.startCase(filename), function () {
           get(path, fn) {
             // We're testing that redirect will get called,
             // so we need to fake invocation of the handler
-            fn(undefined, fakeRes);
+            fn[0](undefined, fakeRes);
           }
         };
 


### PR DESCRIPTION
Amphora currently attaches route-specific middleware by adding two Layers to the router: one for the middleware and then one for the renderer. This PR adds them to the same layer. Basically this is the diff:

```diff
- router.use(path, middleware);
- router.get(path, renderer);
+ router.get(path, [middleware, renderer]);
```

You'll see different behavior if your middleware makes changes to the request (we change the URL for pagination).

The interface for adding routes to a site remains the same:
```javascript
module.exports.routes = [
    { path: "/:name", middleware: [fn] },
    ...
]
```