### PR TITLE
Calls legacyController if present

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -5,6 +5,7 @@ const _ = require('lodash'),
   path = require('path'),
   siteService = require('./services/sites'),
   attachRoutes = require('./services/attachRoutes'),
+  render = require('./render'),
   responses = require('./responses'),
   files = require('./files'),
   plugins = require('./services/plugins'),
@@ -120,6 +121,20 @@ function addCORS(site) {
   };
 }
 
+function setRoutes(controller, router, site) {
+  if (_.isFunction(controller.legacyController)) {
+    controller.legacyController(router, render, site);
+  }
+
+  if (Array.isArray(controller.routes)) {
+    attachRoutes(router, controller.routes, site);
+  }
+
+  if (!controller.legacyController && !controller.routes) {
+    log('warn', `There is no router for site: ${site.slug}`);
+  }
+}
+
 /**
  * Default way to load site controllers.
  *
@@ -154,12 +169,7 @@ function addSiteController(router, site, providers) {
         router.use(controller.middleware);
       }
 
-      if (Array.isArray(controller.routes)) {
-        attachRoutes(router, controller.routes, site);
-      } else {
-        log('warn', `There is no router for site: ${site.slug}`);
-      }
-
+      setRoutes(controller, router, site);
       // Providers are the same across all sites, but this is a convenient
       // place to store it so that it's available everywhere
       _.set(site, 'providers', providers);

--- a/lib/routes.test.js
+++ b/lib/routes.test.js
@@ -388,18 +388,23 @@ describe(_.startCase(filename), function () {
       fn(router, site);
     });
 
-    it('does nothing if site controller is not a function', function () {
-      const siteDir = 'some-location',
+    it('calls legacyController if defined', function () {
+      const controller = sandbox.stub(),
+        siteDir = 'some-location',
         router = {},
         site = { dir: siteDir };
 
       siteService.getParentSite.returns(_.cloneDeep(site));
       sandbox.stub(files, 'tryRequire');
-
-      files.tryRequire.returns({});
+      files.tryRequire.returns({
+        legacyController: controller
+      });
 
       fn(router, site);
+
+      sinon.assert.called(controller);
     });
+
 
     it('calls `attachRoutes` if the `routes` Array is defined', function () {
       const siteDir = 'some-location',


### PR DESCRIPTION
Restores routing API removed here 79f75b83984cd833b07c9326ad54b84a2eece8b2

Site controllers can export a function called legacyController which amphora calls with the router and renderer.