### PR TITLE
add specificity to bootstrap yaml execution

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -31,7 +31,7 @@ function getConfig(dir) {
   dir = path.resolve(dir);
 
   // remove extension
-  dir = dir.replace(/.(yaml|yml)/, '');
+  dir = dir.replace(/.(yaml|yml)i/, '');
 
   if (files.isDirectory(dir)) {
     // default to bootstrap.yaml or bootstrap.yml

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -31,12 +31,14 @@ function getConfig(dir) {
   dir = path.resolve(dir);
 
   // remove extension
-  dir = dir.replace(/.(yaml|yml)i/, '');
+  dir = dir.replace(/.(yaml|yml)/i, '');
 
   if (files.isDirectory(dir)) {
     // default to bootstrap.yaml or bootstrap.yml
     dir = path.join(dir, 'bootstrap');
   }
+
+  console.log('dir', dir);
 
   return files.getYaml(dir);
 }

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -38,8 +38,6 @@ function getConfig(dir) {
     dir = path.join(dir, 'bootstrap');
   }
 
-  console.log('dir', dir);
-
   return files.getYaml(dir);
 }
 

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -30,10 +30,8 @@ var log = require('./services/logger').setup({
 function getConfig(dir) {
   dir = path.resolve(dir);
 
-  if (dir.indexOf('.', 2) > 0) {
-    // remove extension
-    dir = dir.substring(0, dir.indexOf('.', 2));
-  }
+  // remove extension
+  dir = dir.replace(/.(yaml|yml)/, '');
 
   if (files.isDirectory(dir)) {
     // default to bootstrap.yaml or bootstrap.yml
@@ -357,3 +355,4 @@ module.exports.bootstrapPath = bootstrapPath;
 module.exports.setLog = mock => log = mock;
 module.exports.setDb = mock => db = mock;
 module.exports.bootstrapSite = bootstrapSite;
+module.exports.getConfig = getConfig;

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -256,4 +256,21 @@ describe(_.startCase(filename), function () {
       });
     });
   });
+
+  describe('getConfig', function () {
+    const fn = lib[this.title];
+
+    beforeEach(function () {
+      sandbox.stub(files, 'getYaml');
+    });
+
+    it('handles file paths that include a dot-delimitted name', function () {
+      const dir = '/user.name/test/fixtures/config/bootstrap';
+
+      files.getYaml.returns({});
+
+      fn(`${dir}.yaml`);
+      sinon.assert.calledWith(files.getYaml, dir);
+    });
+  });
 });


### PR DESCRIPTION
bugfix for component bootstrap failing on startup due to my local username (reuben.son) throwing off the parser for yaml directory