### PR TITLE
remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "express-flash": "0.0.2",
     "express-session": "^1.14.1",
     "glob": "^7.0.0",
-    "handlebars": "^4.0.5",
     "highland": "^2.11.1",
     "ioredis": "^4.0.0",
     "js-yaml": "^3.2.0",


### PR DESCRIPTION
I was just chatting with Jordan about handlebars version disparities across the clay ecosystem and noticed that `amphora` specifies a handlebars dependency but never requires the library, and the tests all pass when it's removed - so that's what this PR does!