### PR TITLE
Fallback routes

### DIFF
--- a/lib/services/attachRoutes.js
+++ b/lib/services/attachRoutes.js
@@ -82,6 +82,18 @@ function attachDynamicRoute(router, { path, dynamicPage }) {
 }
 
 /**
+ * Attaches a route that attempts to do a plain get and then if no uri is found
+ * gets a fallback dynamic page instead
+ * @param {Router} router 
+ * @param {Object} route
+ * @param {String} route.path
+ * @param {String} route.fallback
+ */
+function attachFallbackRoute(router, { path, fallback }) {
+  return router.get(path, render, render.renderDynamicRoute(fallback));
+}
+
+/**
  * Parses site route config object.
  * @param {Router} router
  * @param {Object} routeObj - Route config
@@ -103,6 +115,8 @@ function parseHandler(router, routeObj, site) {
     return attachRedirect(router, routeObj, site);
   } else if (dynamicPage) {
     return attachDynamicRoute(router, routeObj); // Pass in the page ID
+  } else if (fallback) {
+    return attachFallbackRoute(router, routeObj); // Does normal route then dynamic as a fallback
   } else {
     return attachPlainRoute(router, routeObj);
   }

--- a/lib/services/attachRoutes.js
+++ b/lib/services/attachRoutes.js
@@ -101,7 +101,7 @@ function attachFallbackRoute(router, { path, fallback }) {
  * @return {Router}
  */
 function parseHandler(router, routeObj, site) {
-  const { redirect, dynamicPage, path, middleware } = routeObj;
+  const { redirect, dynamicPage, fallback, path, middleware } = routeObj;
 
   if (!validPath(path, site)) {
     return;

--- a/lib/services/attachRoutes.js
+++ b/lib/services/attachRoutes.js
@@ -84,10 +84,11 @@ function attachDynamicRoute(router, { path, dynamicPage }) {
 /**
  * Attaches a route that attempts to do a plain get and then if no uri is found
  * gets a fallback dynamic page instead
- * @param {Router} router 
+ * @param {Router} router
  * @param {Object} route
  * @param {String} route.path
  * @param {String} route.fallback
+ * @return {Router}
  */
 function attachFallbackRoute(router, { path, fallback }) {
   return router.get(path, render, render.renderDynamicRoute(fallback));

--- a/lib/services/attachRoutes.test.js
+++ b/lib/services/attachRoutes.test.js
@@ -13,6 +13,7 @@ describe(_.startCase(filename), function () {
       { path: '/section/' },
       { path: '/section', redirect: '/section/' },
       { path: '/news/:tag', dynamicPage: 'somePageId' },
+      { path: '/tags/:tag', fallback: 'tags'},
       { path: '/example', middleware: [() => {}] }
     ],
     siteConfigMock = {};


### PR DESCRIPTION
Adds a new type of route `fallback` that is a combination of a regular route that gets normal pages and a dynamic route that fetches one dynamic page. This allows the creation of static pages to replace dynamic pages, and also when those static pages are removed they are replaced by a dynamic page again. 