### PR TITLE
Add db paginate

### DIFF
--- a/lib/responses.js
+++ b/lib/responses.js
@@ -449,15 +449,6 @@ function listWithoutVersions() {
   return list(options);
 }
 
-function paginateComponents(previous, size) {
-  // const options = {
-  //   previous: req.query.prev, 
-  //   size: req.query.size || 0
-  // }
-
-  return list();
-}
-
 /**
  * List all things in the db that start with this prefix
  * _and_ are published
@@ -569,7 +560,6 @@ module.exports.checkArchivedToPublish = checkArchivedToPublish;
 // straight from DB
 module.exports.list = list;
 module.exports.listWithPublishedVersions = listWithPublishedVersions;
-module.exports.paginateComponents = paginateComponents;
 module.exports.listWithoutVersions = listWithoutVersions;
 module.exports.getRouteFromDB = getRouteFromDB;
 module.exports.putRouteFromDB = putRouteFromDB;

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -421,7 +421,9 @@ function list(options) {
     let list,
       listOptions = _.assign({
         prefix: req.uri,
-        values: false
+        values: false,
+        previous: req.query.prev, 
+        size: req.query.size || 0
       }, options);
 
     list = db.list(listOptions);
@@ -441,10 +443,19 @@ function listWithoutVersions() {
       return [filter({wantStrings: true}, function (str) {
         return str.indexOf('@') === -1;
       })];
-    }
+    }, 
   };
 
   return list(options);
+}
+
+function paginateComponents(previous, size) {
+  // const options = {
+  //   previous: req.query.prev, 
+  //   size: req.query.size || 0
+  // }
+
+  return list();
 }
 
 /**
@@ -558,6 +569,7 @@ module.exports.checkArchivedToPublish = checkArchivedToPublish;
 // straight from DB
 module.exports.list = list;
 module.exports.listWithPublishedVersions = listWithPublishedVersions;
+module.exports.paginateComponents = paginateComponents;
 module.exports.listWithoutVersions = listWithoutVersions;
 module.exports.getRouteFromDB = getRouteFromDB;
 module.exports.putRouteFromDB = putRouteFromDB;

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -80,7 +80,7 @@ function list(options = {}) {
     transformOptions.isArray = true;
   }
 
-  readStream = module.exports.createReadStream(options);
+  readStream = module.exports.paginate(options);
 
   if (_.isFunction(options.transforms)) {
     options.transforms = options.transforms();
@@ -136,6 +136,7 @@ module.exports.patchMeta;
 module.exports.getMeta;
 module.exports.raw;
 module.exports.createReadStream;
+module.exports.paginate;
 
 // For testing
 module.exports.defer = defer;


### PR DESCRIPTION
Sets us up for pagination to list endpoints like `/_components/instances`
- Calls `db.paginate()` for list requests
- Adds `prev` and `size` query params to list requests

Requires https://github.com/clay/amphora-storage-postgres/pull/64 for pagination.