### PR TITLE
Introduces release workflow via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,19 +8,19 @@ references:
       tags:
         only: /.*/
 
-  filter_stg: &filter_stg
+  filter_stg: &filter_head
     filters:
       branches:
         only: master
       tags:
         only: stg
 
-  filter_prd: &filter_prd
+  filter_prd: &filter_release
     filters:
       branches:
         ignore: /.*/
       tags:
-        only: /v[0-9]+\.[0-9]+\.[0-9]+/
+        only: /v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?/
 
 jobs:
 
@@ -94,6 +94,26 @@ jobs:
           paths:
             - website/node_modules
 
+  deploy_package:
+    docker:
+      - image: circleci/node:12
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v3-node12-dependencies-{{ checksum "package.json" }}
+          - v3-node12-dependencies-
+      - run: npm install
+      - run: |
+          echo "$NPMRC" > ~/.npmrc
+          chmod 600 ~/.npmrc
+          if [[ "$CIRCLE_TAG" = *-* ]]; then
+            npm publish --tag=prerelease
+          else
+            npm publish
+          fi
+
 workflows:
   version: 2
   test:
@@ -105,9 +125,18 @@ workflows:
       - test_node14:
           <<: *filter_all
       - deploy_docs:
+          <<: *filter_head
           context:
             - Documentation
           requires:
+            - test_node10
             - test_node12
             - test_node14
-          <<: *filter_stg
+      - deploy_package:
+          <<: *filter_release
+          context:
+            - npm-publish
+          requires:
+            - test_node10
+            - test_node12
+            - test_node14

--- a/.circleci/scripts/release.sh
+++ b/.circleci/scripts/release.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This script will increment the package version in package.json.
+# It will then tag the HEAD of the master branch with the version number
+# and push the tag to the origin (GitHub)
+
+set -e
+
+OPTIONS="(prepatch|patch|preminor|minor|premajor|major)"
+USAGE="usage: npm release $OPTIONS"
+SEMVAR="$1"
+
+# Releases should only be cut from the master branch.
+# They can be manually cut from other branches, but that should be a very
+# intentional process.
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$BRANCH" != "master" ]]; then
+    >&2 echo "ERROR: Not on the master branch, will not release."
+    exit 1
+fi
+
+case $SEMVAR in
+    minor)
+        ;;
+    major)
+        ;;
+    patch)
+        ;;
+    premajor)
+        ;;
+    preminor)
+        ;;
+    prepatch)
+        ;;
+    *)
+        SEMVAR=prepatch
+        >&2 echo "WARNING: No $OPTIONS provided, defaulting to PREPATCH."
+        >&2 echo "$USAGE"
+        ;;
+esac
+
+git pull --rebase origin master
+version="$(npm version $SEMVAR)"
+git push origin master
+git push origin "tags/$version"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "npm run eslint && npm run mocha",
     "eslint": "eslint --max-warnings 0 lib test",
-    "mocha": "istanbul cover _mocha"
+    "mocha": "istanbul cover _mocha",
+    "release": "./.circleci/scripts/release.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The typical workflow will involve creating a release from the **base** branch (currently: `master`).

1. Start by creating a prerelease candidate, selecting the correct version to increment.
```sh
npm run release (prepatch|preminor|premajor)
```

2. This will run `npm version (selection)` and push the branch/tag.

3. CircleCI will publish a package with `--tag=prerelease`, eg. `v8.17.1-0`.

4. When we are ready to promote a release from `prerelease` to `latest` run the following.
```sh
npm run release (patch|minor|major)
```

5. This will run `npm version (selection)` and push the branch/tag.

6. CircleCI will publish a package, eg `v8.17.1`.