### PR TITLE
improves logging for explicitly handled errors

### DIFF
--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -12,7 +12,6 @@ const _ = require('lodash'),
 
 describe(_.startCase(filename), function () {
   let sandbox,
-    bootstrapFake, // eslint-disable-line
     db,
     sitesFake,
     fakeLog;
@@ -41,8 +40,6 @@ describe(_.startCase(filename), function () {
       prefix: 'example4.com',
       subsite: 'example4'
     }];
-
-    bootstrapFake = files.getYaml(path.resolve('./test/fixtures/config/bootstrap')); // eslint-disable-line
   });
 
   beforeEach(function () {

--- a/lib/bootstrap.test.js
+++ b/lib/bootstrap.test.js
@@ -42,7 +42,7 @@ describe(_.startCase(filename), function () {
       subsite: 'example4'
     }];
 
-    bootstrapFake = files.getYaml(path.resolve('./test/fixtures/config/bootstrap'));
+    bootstrapFake = files.getYaml(path.resolve('./test/fixtures/config/bootstrap')); // eslint-disable-line
   });
 
   beforeEach(function () {

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -303,9 +303,10 @@ function notFound(err, res) {
  */
 function serverError(err, res) {
   const message = err.message || 'Server Error', // completely hide these messages from outside
-    code = 500;
+    code = 500,
+    level = logLevelFromStatusCode(code);
 
-  log('error', err.message, { code, stack: err.stack, url: _.get(res, 'locals.url') });
+  log(level, err.message, { code, stack: err.stack, url: _.get(res, 'locals.url') });
 
   sendDefaultResponseForCode(code, message, res);
 }
@@ -332,9 +333,10 @@ function unauthorized(res) {
 function clientError(err, res) {
   // They know it's a 400 already, we don't need to repeat the fact that its an error.
   const message = removePrefix(err.message, ':'),
-    code = 400;
+    code = 400,
+    level = logLevelFromStatusCode(code);
 
-  log('warn', err.message, { code, stack: err.stack, url: _.get(res, 'locals.url') });
+  log(level, err.message, { code, stack: err.stack, url: _.get(res, 'locals.url') });
 
   sendDefaultResponseForCode(code, message, res);
 }

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -146,7 +146,7 @@ function notImplemented(req, res) {
   const code = 501,
     message = 'Not Implemented';
 
-  log('error', message, { code });
+  log('warn', message, { code, url: req.url });
 
   sendDefaultResponseForCode(code, message, res);
 }
@@ -168,9 +168,6 @@ function methodNotAllowed(options) {
     } else {
       code = 405;
       message = 'Method ' + method + ' not allowed';
-
-      log('error', message, { code });
-
       res.set('Allow', allowed.join(', ').toUpperCase());
       sendDefaultResponseForCode(code, message, res, options);
     }
@@ -194,9 +191,6 @@ function notAcceptable(options) {
     } else {
       code = 406;
       message = req.get('Accept') + ' not acceptable';
-
-      log('error', message, { code });
-
       res.set('Accept', acceptableTypes.join(', ').toLowerCase());
       sendDefaultResponseForCode(code, message, res, options);
     }
@@ -210,12 +204,7 @@ function notAcceptable(options) {
  */
 function denyTrailingSlashOnId(req, res, next) {
   if (_.last(req.path) === '/') {
-    const code = 400,
-      message = 'Trailing slash on RESTful id in URL is not acceptable';
-
-    log('error', message, { code });
-
-    sendDefaultResponseForCode(code, message, res);
+    sendDefaultResponseForCode(400, 'Trailing slash on RESTful id in URL is not acceptable', res);
   } else {
     next();
   }
@@ -231,12 +220,7 @@ function denyReferenceAtRoot(req, res, next) {
   const body = req.body;
 
   if (_.has(body, '_ref')) {
-    const code = 400,
-      message = 'Reference (_ref) at root of object is not acceptable';
-
-    log('error', message, { code });
-
-    sendDefaultResponseForCode(code, message, res);
+    sendDefaultResponseForCode(400, 'Reference (_ref) at root of object is not acceptable', res);
   } else {
     next();
   }
@@ -289,8 +273,6 @@ function notFound(err, res) {
   const message = 'Not Found',
     code = 404;
 
-  log('error', message, { code });
-
   // hide error from user of api.
   sendDefaultResponseForCode(code, message, res);
 }
@@ -322,8 +304,6 @@ function unauthorized(res) {
     message = removePrefix(err.message, ':'),
     code = 401;
 
-  log('error', err.message, { code });
-
   sendDefaultResponseForCode(code, message, res);
 }
 
@@ -351,7 +331,10 @@ function clientError(err, res) {
 function handleError(res) {
   return function (err) {
     if (err.status && err.name !== 'NotFoundError') {
-      log('error', err.message, { code: err.status, stack: err.stack });
+      if (err.status >= 500) {
+        log('error', err.message, { code: err.status, stack: err.stack });
+      }
+
       // If we're in this block, the error has a defined `status` property and
       // the error should be directed out immediately
       sendDefaultResponseForCode(err.status, err.message, res);

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -10,6 +10,25 @@ const _ = require('lodash'),
   metaController = require('./services/metadata');
 
 /**
+ * Returns a the name of the log level appropriate for a given HTTP response code.
+ * - 5xx = error
+ * - 4xx = warn
+ * - default = info
+ *
+ * @param {number} code: An HTTP status code.
+ * @returns {string}
+ */
+function logLevelFromStatusCode(code) {
+  if (code >= 500) {
+    return 'error';
+  }
+  if (code >= 400) {
+    return 'warn';
+  }
+  return 'info';
+}
+
+/**
  * Finds prefixToken, and removes it and anything before it.
  *
  * @param {string} str
@@ -145,8 +164,6 @@ function sendDefaultResponseForCode(code, message, res, extras) {
 function notImplemented(req, res) {
   const code = 501,
     message = 'Not Implemented';
-
-  log('warn', message, { code, url: req.url });
 
   sendDefaultResponseForCode(code, message, res);
 }
@@ -288,14 +305,13 @@ function serverError(err, res) {
   const message = err.message || 'Server Error', // completely hide these messages from outside
     code = 500;
 
-  // error is required to be logged
   log('error', err.message, { code, stack: err.stack, url: _.get(res, 'locals.url') });
 
   sendDefaultResponseForCode(code, message, res);
 }
 
 /**
- * All client errors should look like this.
+ * All unauthorized requests should look like this.
  *
  * @param {object} res
  */
@@ -324,6 +340,22 @@ function clientError(err, res) {
 }
 
 /**
+ * This function dispatches an errors that have a manually set .status attribute.
+ * The .status attribute indicates that the error was intentionally constructed
+ * or caught and assigned a specific response code/message.
+ *
+ * @param {Error} err
+ * @param {object} res
+ */
+function explicitError(err, res) {
+  const code = err.status,
+    level = logLevelFromStatusCode(code);
+
+  log(level, err.message, { code, stack: err.stack, url: _.get(res, 'locals.url') });
+  sendDefaultResponseForCode(code, err.message, res);
+}
+
+/**
  * Handle errors in the standard/generic way
  * @param {object} res
  * @returns {function}
@@ -333,7 +365,7 @@ function handleError(res) {
     if (err.status && err.name !== 'NotFoundError') {
       // If we're in this block, the error has a defined `status` property and
       // the error should be directed out immediately
-      sendDefaultResponseForCode(err.status, err.message, res);
+      explicitError(err, res);
     } else if (err.name === 'NotFoundError' ||
       err.message.indexOf('ENOENT') !== -1 ||
       err.message.indexOf('not found') !== -1) {

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -146,6 +146,8 @@ function notImplemented(req, res) {
   const code = 501,
     message = 'Not Implemented';
 
+  log('error', message, { code });
+
   sendDefaultResponseForCode(code, message, res);
 }
 
@@ -166,6 +168,9 @@ function methodNotAllowed(options) {
     } else {
       code = 405;
       message = 'Method ' + method + ' not allowed';
+
+      log('error', message, { code });
+
       res.set('Allow', allowed.join(', ').toUpperCase());
       sendDefaultResponseForCode(code, message, res, options);
     }
@@ -189,6 +194,9 @@ function notAcceptable(options) {
     } else {
       code = 406;
       message = req.get('Accept') + ' not acceptable';
+
+      log('error', message, { code });
+
       res.set('Accept', acceptableTypes.join(', ').toLowerCase());
       sendDefaultResponseForCode(code, message, res, options);
     }
@@ -202,7 +210,12 @@ function notAcceptable(options) {
  */
 function denyTrailingSlashOnId(req, res, next) {
   if (_.last(req.path) === '/') {
-    sendDefaultResponseForCode(400, 'Trailing slash on RESTful id in URL is not acceptable', res);
+    const code = 400,
+      message = 'Trailing slash on RESTful id in URL is not acceptable';
+
+    log('error', message, { code });
+
+    sendDefaultResponseForCode(code, message, res);
   } else {
     next();
   }
@@ -218,7 +231,12 @@ function denyReferenceAtRoot(req, res, next) {
   const body = req.body;
 
   if (_.has(body, '_ref')) {
-    sendDefaultResponseForCode(400, 'Reference (_ref) at root of object is not acceptable', res);
+    const code = 400,
+      message = 'Reference (_ref) at root of object is not acceptable';
+
+    log('error', message, { code });
+
+    sendDefaultResponseForCode(code, message, res);
   } else {
     next();
   }
@@ -271,6 +289,8 @@ function notFound(err, res) {
   const message = 'Not Found',
     code = 404;
 
+  log('error', message, { code });
+
   // hide error from user of api.
   sendDefaultResponseForCode(code, message, res);
 }
@@ -283,11 +303,11 @@ function notFound(err, res) {
  * @param {object} res
  */
 function serverError(err, res) {
-  // error is required to be logged
-  log('error', err.message, { stack: err.stack, url: _.get(res, 'locals.url') });
-
   const message = err.message || 'Server Error', // completely hide these messages from outside
     code = 500;
+
+  // error is required to be logged
+  log('error', err.message, { code, stack: err.stack, url: _.get(res, 'locals.url') });
 
   sendDefaultResponseForCode(code, message, res);
 }
@@ -302,6 +322,8 @@ function unauthorized(res) {
     message = removePrefix(err.message, ':'),
     code = 401;
 
+  log('error', err.message, { code });
+
   sendDefaultResponseForCode(code, message, res);
 }
 
@@ -312,10 +334,11 @@ function unauthorized(res) {
  * @param {object} res
  */
 function clientError(err, res) {
-  log('error', err.message, { stack: err.stack, url: _.get(res, 'locals.url') });
   // They know it's a 400 already, we don't need to repeat the fact that its an error.
   const message = removePrefix(err.message, ':'),
     code = 400;
+
+  log('warn', err.message, { code, stack: err.stack, url: _.get(res, 'locals.url') });
 
   sendDefaultResponseForCode(code, message, res);
 }
@@ -328,6 +351,7 @@ function clientError(err, res) {
 function handleError(res) {
   return function (err) {
     if (err.status && err.name !== 'NotFoundError') {
+      log('error', err.message, { code: err.status, stack: err.stack });
       // If we're in this block, the error has a defined `status` property and
       // the error should be directed out immediately
       sendDefaultResponseForCode(err.status, err.message, res);

--- a/lib/responses.js
+++ b/lib/responses.js
@@ -331,10 +331,6 @@ function clientError(err, res) {
 function handleError(res) {
   return function (err) {
     if (err.status && err.name !== 'NotFoundError') {
-      if (err.status >= 500) {
-        log('error', err.message, { code: err.status, stack: err.stack });
-      }
-
       // If we're in this block, the error has a defined `status` property and
       // the error should be directed out immediately
       sendDefaultResponseForCode(err.status, err.message, res);

--- a/lib/responses.test.js
+++ b/lib/responses.test.js
@@ -111,13 +111,29 @@ describe(_.startCase(filename), function () {
       fn(res)(new Error('something'));
     });
 
-    it('sends the error code defined in the `status` property', function (done) {
+    it('sends the error code defined in the `status` property, 4xx', function (done) {
       const res = createMockRes(),
         myError = new Error('something');
 
       myError.status = 403;
       expectStatus(res, 403);
-      expectResult(res, 'sendStatus: whatever', done);
+      expectResult(res, 'sendStatus: whatever', function () {
+        sinon.assert.calledWith(fakeLog, 'warn');
+        done();
+      });
+      fn(res)(myError);
+    });
+
+    it('sends the error code defined in the `status` property, 5xx', function (done) {
+      const res = createMockRes(),
+        myError = new Error('something');
+
+      myError.status = 500;
+      expectStatus(res, 500);
+      expectResult(res, 'sendStatus: whatever', function () {
+        sinon.assert.calledWith(fakeLog, 'error');
+        done();
+      });
       fn(res)(myError);
     });
   });
@@ -190,7 +206,7 @@ describe(_.startCase(filename), function () {
 
       expectStatus(res, 501);
       expectResult(res, 'sendStatus: whatever', function () {
-        sinon.assert.calledWith(fakeLog, 'warn');
+        expectNoLogging();
         done();
       });
       fn({}, res);

--- a/lib/responses.test.js
+++ b/lib/responses.test.js
@@ -145,7 +145,7 @@ describe(_.startCase(filename), function () {
 
       expectStatus(res, 400);
       expectResult(res, 'sendStatus: whatever', function () {
-        sinon.assert.calledWith(fakeLog, 'error');
+        sinon.assert.calledWith(fakeLog, 'warn');
         done();
       });
       fn(new Error('something'), res);
@@ -190,7 +190,7 @@ describe(_.startCase(filename), function () {
 
       expectStatus(res, 501);
       expectResult(res, 'sendStatus: whatever', function () {
-        expectNoLogging();
+        sinon.assert.calledWith(fakeLog, 'warn');
         done();
       });
       fn({}, res);

--- a/lib/services/composer.js
+++ b/lib/services/composer.js
@@ -31,11 +31,12 @@ function resolveComponentReferences(data, locals, filter = referenceProperty) {
             cmpt: referenceObject[referenceProperty]
           };
 
-          if (error.status) {
-            logObj.status = error.status;
+          // Errors with a .status property will be handled by lib/responses.js
+          // and logged with a level corresponding to the status code.
+          if (!error.status) {
+            log('error', `${error.message}`, logObj);
           }
 
-          log('error', `${error.message}`, logObj);
 
           return bluebird.reject(error);
         });

--- a/lib/services/composer.test.js
+++ b/lib/services/composer.test.js
@@ -113,7 +113,7 @@ describe(_.startCase(filename), function () {
       });
     });
 
-    it('adds the status to the error message if it one is defined', function () {
+    it('adds the status to the error message if it one is defined, skips log', function () {
       const data = {
           a: {_ref: '/c/b'},
           c: {d: {_ref: '/c/e'}}
@@ -127,9 +127,8 @@ describe(_.startCase(filename), function () {
       components.get.withArgs('/c/m').returns(bluebird.reject(myError));
 
       return fn(data).catch((error) => {
-        sinon.assert.calledOnce(logSpy);
         expect(error.message).to.equal(errorMessage);
-        sinon.assert.calledWith(logSpy, 'error', errorMessage, { status: myError.status, cmpt: '/c/e', stack: myError.stack });
+        expect(error.status).to.equal(404);
       });
     });
   });


### PR DESCRIPTION
This pull request incorporates elements of #693 with a few additional changes:

1. I rebased the branch against `origin/master` to handle merge conflicts for existing logging updates.
2. I removed logging in the `composer.js` when an error has a `.status` (leaving the logging up to the error handler in `responses.js`).
3. I added a method to log errors with an explicit `.status` property at the `warn` (4xx) or `error` (5xx) level.

Change (1) pulls in a previous commit that added URLs to response logs.
Change (2/3) will allow dynamic routes to return 404s/400s without logging at the `error` level.