### PR TITLE
ON-3278 | add user info to event bus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
           paths:
             - node_modules
       - run: npm test
-      - run: cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
   test_node14:
     docker:

--- a/lib/services/db-operations.js
+++ b/lib/services/db-operations.js
@@ -105,8 +105,18 @@ function getPutOperations(putFn, uri, data, locals) {
   }
 
   // run each through the normal put, which may or may not hit custom component logic
-  return bluebird.map(cmptOrLayout, ({ key, value }) => putFn(key, value, locals))
-    .then(ops => _.filter(_.flattenDeep(ops), _.identity));
+  return bluebird
+    .map(cmptOrLayout, ({ key, value }) => putFn(key, value, locals))
+    .then(ops => _.filter(_.flattenDeep(ops), _.identity))
+    .then(ops => {
+      function addUserProp(op) {
+        op.user = locals.user;
+      }
+
+      ops.forEach(addUserProp);
+
+      return ops;
+    });
 }
 
 /**

--- a/lib/services/db-operations.js
+++ b/lib/services/db-operations.js
@@ -81,6 +81,30 @@ function splitCascadingData(uri, data) {
 }
 
 /**
+ * Adds user info onto each op object
+ *
+ * @param {Object} locals
+ * @param {Object} locals.user
+ * @returns {Function}
+ */
+function addUserInfoToOp(locals) {
+  if (!locals) {
+    return _.identity;
+  }
+
+  const { user } = locals;
+
+  function addUserProp(op) {
+    op.user = user;
+  }
+
+  return (opsList) => {
+    opsList.forEach(addUserProp);
+    return opsList;
+  };
+}
+
+/**
  * Get a list of all the put operations needed to complete a cascading PUT
  *
  * NOTE: this function changes the data object _in-place_ for speed and memory reasons. We are not okay with doing
@@ -108,15 +132,7 @@ function getPutOperations(putFn, uri, data, locals) {
   return bluebird
     .map(cmptOrLayout, ({ key, value }) => putFn(key, value, locals))
     .then(ops => _.filter(_.flattenDeep(ops), _.identity))
-    .then(ops => {
-      function addUserProp(op) {
-        op.user = locals.user;
-      }
-
-      ops.forEach(addUserProp);
-
-      return ops;
-    });
+    .then(addUserInfoToOp(locals));
 }
 
 /**

--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -27,13 +27,17 @@ const _ = require('lodash'),
  * @param {string} uri
  * @param {{}} data
  * @param {[]} ops
+ * @param {{}} locals
  * @returns {array}
  */
-function addOp(uri, data, ops) {
+function addOp(uri, data, ops, locals = {}) {
+  const { user } = locals;
+
   ops.push({
     type: 'put',
     key: uri,
-    value: JSON.stringify(data)
+    value: JSON.stringify(data),
+    user
   });
 
   return ops;
@@ -257,7 +261,7 @@ function publish(uri, data, locals) {
           publishedMeta = meta;
 
           // add page PUT operation last
-          return addOp(replaceVersion(uri, published), pageData, ops);
+          return addOp(replaceVersion(uri, published), pageData, ops, locals);
         });
     })
     .then(applyBatch)
@@ -306,7 +310,7 @@ function create(uri, data, locals) {
       return getPageClonePutOperations(pageData, locals)
         .then(ops => {
           pageData.layout = layoutReference;
-          return addOp(pageReference, pageData, ops);
+          return addOp(pageReference, pageData, ops, locals);
         });
     })
     .then(applyBatch)


### PR DESCRIPTION
* This change adds `user` data to event topics that were missing it. This makes the event bus payload more consistent and allows for granular tracking by user.