### PR TITLE
Adds errorHandler plugin

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var uriRoutes, renderers,
+var uriRoutes, renderers, errorHandler,
   db = require('./services/db'),
   log = require('./services/logger').setup({
     file: __filename,
@@ -265,6 +265,16 @@ function logTime(hrStart, uri) {
 }
 
 /**
+ * Passes page error handling back to the site.
+ *
+* @param {Function} handler - (error, response, next) => {}
+*/
+function registerErrorHandler(handler) {
+  errorHandler = handler;
+}
+
+
+/**
  * Run composer by translating url to a "page" by base64ing it.  Errors are handled by Express.
  *
  * @param {Object} req
@@ -280,13 +290,17 @@ function renderExpressRoute(req, res, next) {
 
   return module.exports.renderUri(pageReference, req, res, hrStart)
     .catch((error) => {
-      if (error.name === 'NotFoundError') {
-        log('info', `could not find resource ${req.uri}`, {
-          message: error.message
-        });
-        next();
+      if (errorHandler) {
+        errorHandler(error, res, next);
       } else {
-        next(error);
+        if (error.name === 'NotFoundError') {
+          log('info', `could not find resource ${req.uri}`, {
+            message: error.message
+          });
+          next();
+        } else {
+          next(error);
+        }
       }
     });
 }
@@ -373,6 +387,7 @@ module.exports.findRenderer = findRenderer;
 // Setup
 module.exports.renderers = {}; // Overriden when a user registers a render object
 module.exports.registerRenderers = registerRenderers;
+module.exports.registerErrorHandler = registerErrorHandler;
 
 // For Testing
 module.exports.resetUriRouteHandlers = resetUriRouteHandlers;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -35,6 +35,7 @@ module.exports = function (options = {}) {
       providers = [],
       sessionStore,
       renderers,
+      errorHandler,
       plugins = [],
       bootstrap = true,
       storage = false,
@@ -56,6 +57,10 @@ module.exports = function (options = {}) {
   // if engines were passed in, send them to the renderer
   if (renderers) {
     render.registerRenderers(renderers);
+  }
+
+  if (errorHandler) {
+    render.registerErrorHandler(errorHandler);
   }
 
   // Make sure the storage module is run, then bootstrap


### PR DESCRIPTION
Modifies `renderExpressRoute` to pass page rendering errors back to the site. This enables our site middleware to respond to 404s and other errors.

To use this, initialize amphora with a function named `errorHandler`. This field is optional; if you don't provide it, you'll see the current behavior.