### PR TITLE
🍕 Rendering routes: Decode uris before rendering to prevent unexpected failures

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -286,7 +286,11 @@ function renderExpressRoute(req, res, next) {
   var hrStart = process.hrtime(),
     site = res.locals.site,
     prefix = `${getExpressRoutePrefix(site)}/_uris/`,
-    pageReference = `${prefix}${buf.encode(req.hostname + req.baseUrl + req.path)}`;
+    // We're using decodeURIComponent to match any encoded value that might be sent by the browser.
+    // An example of this is a smart quote ’ -- That value is going to be encoded to `%E2%80%99`.
+    // We store the actual symbol in our database, not the encoded value, so, when decoding it, we ensure we can get the direct symbol
+    // and, in consequence, the page we're looking for.
+    pageReference = `${prefix}${buf.encode(req.hostname + req.baseUrl + decodeURIComponent(req.path))}`;
 
   return module.exports.renderUri(pageReference, req, res, hrStart)
     .catch((error) => {


### PR DESCRIPTION
We're using `decodeURIComponent` to match any encoded value that might be sent/encoded by the browser. An example of this is a smart quote ’ -- That value is going to be encoded to `%E2%80%99`. We store the actual symbol in our database, not the encoded value, so, when decoding it, we need to ensure we can get the direct symbol and, in consequence, the page we're looking for.