### PR TITLE
🍕 Fix pre-publish site controller reference

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -177,6 +177,7 @@ function addSiteController(router, site, providers) {
       _.assign(site, _.pick(controller, 'resolvePublishing'));
       _.assign(site, _.pick(controller, 'resolvePublishUrl'));
       _.assign(site, _.pick(controller, 'modifyPublishedData'));
+      _.assign(site, _.pick(controller, 'assignToMetaOnPublish'));
     }
   }
 


### PR DESCRIPTION
This function is not being executed in our clay instance because it is not being picked up and assigned to the site's controller. It's a function to add metadata to a page's meta. 