### PR TITLE
Allow config option for skipping upgrades

### DIFF
--- a/lib/services/upgrade.js
+++ b/lib/services/upgrade.js
@@ -189,6 +189,10 @@ function upgradeData(schemaVersion, dataVersion, ref, data, locals) {
  * @return {Promise}
  */
 function checkForUpgrade(ref, data, locals) {
+  if (locals && locals.disableUpgrades) {
+    return bluebird.resolve(data);
+  }
+
   return utils.getSchema(ref)
     .then(schema => {
       // If version does not match what's in the data

--- a/lib/services/upgrade.test.js
+++ b/lib/services/upgrade.test.js
@@ -77,6 +77,19 @@ describe(_.startCase(filename), function () {
           expect(lib.upgradeData.calledOnce).to.be.true;
         });
     });
+
+    it('does not call upgradeData or getSchema if locals.disableUpgrades is true', function () {
+      let locals = {disableUpgrades: true};
+
+      sandbox.stub(lib, 'upgradeData');
+
+      return fn('site/_components/foo/instances/bar', {_version: 1, value: 'bar'}, locals)
+        .then(function () {
+          expect(lib.upgradeData.calledOnce).to.be.false;
+          expect(utils.getSchema.calledOnce).to.be.false;
+        });
+    });
+
   });
 
   describe('upgradeData', function () {


### PR DESCRIPTION
Fixes #714 - let's a site set `disableUpgrades` to short-circuit upgrading.